### PR TITLE
docs: drop the geographic scope from the toolkit framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 [![EE Image](https://img.shields.io/badge/ghcr.io-cyberaar%2Fee--hardening-blue?logo=docker)](https://github.com/cyberaar/cyberaar-toolkit/pkgs/container/ee-hardening)
 
 **cyberaar-toolkit** is a volunteer-driven, open collaboration to gather and share
-**best practices** for securing Senegal's critical infrastructure against cyber threats.
+**best practices** for securing critical infrastructure against cyber threats.
 
-Inspired by recent attacks on Senegalese public systems, we unite Senegalese talents
-(home & diaspora) + global allies to build a **living, production-ready toolkit**
-available in French & English.
+Born out of the response to attacks on public-sector systems, the project brings
+together practitioners at home, across the diaspora and anywhere else, to build a
+**living, production-ready toolkit** available in French & English.
 
-> *Sécurisons ensemble l'infrastructure numérique du Sénégal.* — 🇸🇳
+> *Sécurisons ensemble les infrastructures numériques critiques.*
 
 ---
 
@@ -676,7 +676,7 @@ Open `before/` and `after/` HTML reports side by side to visualise the security 
 
 Community-maintained security guides and templates have moved to their own repository:
 
-**[cyberaar/Aar-Act](https://github.com/cyberaar/Aar-Act)** — practices (English), translations (French), and Senegal-specific examples.
+**[cyberaar/Aar-Act](https://github.com/cyberaar/Aar-Act)** — practices (English), translations (French), and worked examples.
 
 ---
 
@@ -735,4 +735,4 @@ See the [LICENSE](LICENSE) file for the full text.
 
 ---
 
-*#Cybersecurity #Senegal #AarAct #CyberAar*
+*#Cybersecurity #Hardening #AarAct #CyberAar*


### PR DESCRIPTION
Follows the positioning change already applied to cyberaar.io: geography stays where it is **origin or proof**, and goes where it defines **the market**.

The toolkit hardens CIS baselines on RHEL 9, Ubuntu and Debian. Nothing in it is country-specific, so scoping the README to one country narrowed who recognises it as relevant and who feels invited to contribute, without describing the software any more precisely. It was also the single most visible CyberAar text on the web, so it was doing that work at scale.

| Line | Before | After |
|---|---|---|
| Lead | securing **Senegal's** critical infrastructure | securing critical infrastructure |
| Origin | "we unite **Senegalese** talents (home & diaspora) + global allies" | "practitioners at home, across the diaspora and anywhere else" |
| FR tagline | *l'infrastructure numérique **du Sénégal*** 🇸🇳 | *les infrastructures numériques critiques* |
| Aar-Act ref | "**Senegal-specific** examples" | "worked examples" |
| Footer | `#Senegal` | `#Hardening` |

The origin paragraph deliberately keeps *why* the project started, since that is real credibility. What changes is the implication that the contributor pool is national, which sat oddly next to "global allies" in the same sentence.

"volunteer-driven" is untouched: that is accurate, it is where the stars and forks came from, and changing it is a separate call.

The repo description and topics were updated separately via the API, so this brings the README in line with them.