### PR TITLE
Group dependabot action updates into one monthly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,27 @@
 #
 # Dependabot rewrites the pin and the trailing version comment together, so the
 # pin stays readable while still being an immutable reference.
+#
+# Major versions are deliberately NOT excluded. For GitHub Actions a major bump
+# is almost always the Node runtime moving forward (v4/v5/v6 of checkout, v4 of
+# login-action, v6 of setup-python are all Node 16 -> 20 -> 24), and GitHub
+# eventually stops running the older runtime. Ignoring majors would not freeze
+# behaviour, it would strand the workflows on a runtime that no longer receives
+# fixes: actions/checkout v7.0.0 is a security release that blocks checking out
+# a fork PR under pull_request_target and workflow_run, and a major-version
+# filter would have skipped it silently.
+#
+# The risk worth managing is review fatigue, not the bumps themselves. One
+# grouped PR a month gets read; five separate ones a week get rubber-stamped.
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore(ci)"


### PR DESCRIPTION
## Why

Digest-pinning the actions (#84) froze an immutable reference, and dependabot
immediately opened five separate PRs proposing major bumps.

The volume is the problem, not the bumps. Five PRs a week get rubber-stamped,
which defeats the review that pinning exists to enable.

## What

One grouped PR instead of five, monthly instead of weekly.

## Why majors are not excluded

The obvious reflex is `ignore: version-update:semver-major`. It is the wrong
call here, and the release notes say so:

| Bump | Actual content |
|------|----------------|
| `checkout` v5, v6 | Node 24 runtime |
| `login-action` v4 | Node 24 runtime |
| `setup-python` v6 | "Breaking Changes" = Node 24, runner v2.327.1+ |

For Actions a major is almost always the Node runtime moving forward, and
GitHub retires the older runtime. Ignoring majors would not freeze behaviour,
it would strand the workflows on a runtime that stops receiving fixes.

All five workflows run on `ubuntu-latest`, so the runner floor is satisfied by
GitHub. This repo's `setup-python` usage is `python-version: "3.12"` plus
`cache: pip`, which these majors do not touch.

Most of all, `actions/checkout` v7.0.0 is a security release: it blocks
checking out a fork PR under `pull_request_target` and `workflow_run`, the
pattern that lets an external PR run its own code with repository secrets. A
major-version filter would have skipped it silently.

The reasoning is recorded in the file so the next person does not re-derive it.