### PR TITLE
Bump the five pinned actions to current majors

### DIFF
--- a/.github/workflows/baseline-build.yml
+++ b/.github/workflows/baseline-build.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Run build.sh
         run: bash scripts/build.sh

--- a/.github/workflows/ee-build.yml
+++ b/.github/workflows/ee-build.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Read collection version from galaxy.yml
         id: meta
@@ -30,18 +30,18 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4.3.0
 
       - name: Log in to GitHub Container Registry
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           file: execution-environment/Containerfile

--- a/.github/workflows/galaxy-publish.yml
+++ b/.github/workflows/galaxy-publish.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -82,10 +82,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -123,7 +123,7 @@ jobs:
       # Step is skipped gracefully if the secrets are not configured.
       - name: Log in to Docker Hub
         if: env.DOCKERHUB_USER != ''
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Supersedes #85, #86, #87, #88 and #89 by combining them into one change,
which is what the grouped config in #90 will produce from now on. Merging
five separate PRs would mean five dependabot rebases and five full CI runs
for five one-line edits.

| Action | From | To |
|--------|------|-----|
| `actions/checkout` | v4 | v7.0.1 |
| `actions/setup-python` | v5 | v7.0.0 |
| `docker/build-push-action` | v6 | v7.3.0 |
| `docker/login-action` | v3 | v4.6.0 |
| `docker/setup-buildx-action` | v3 | v4.3.0 |

## Digests verified

Each proposed SHA was resolved against the tag it claims through the git ref
API before being applied. A pin is worth exactly as much as that check, and
taking dependabot's word for it would skip the step the pinning exists for.
All five matched.

## Why the majors are safe here

They are Node runtime bumps (16 to 20 to 24). All five workflows run on
`ubuntu-latest`, so the runner floor those releases require is met by GitHub.
`setup-python` is used only with `python-version: "3.12"` and `cache: pip`,
neither of which these releases touch.

The one genuine behaviour change is `checkout` v7.0.0 refusing to check out a
fork PR under `pull_request_target` or `workflow_run`. That is a security fix,
and it does not apply here: no workflow uses either trigger, and no checkout
step passes an explicit `ref` or `repository`.