### PR TITLE
SYS-11: detect a kernel that is installed but not running

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -237,6 +237,15 @@ Checks marked **(manual review)** cannot be automatically remediated, the script
 | SYS-08 | Secure Boot enabled | WARN | `secureboot` | Uses `mokutil --sb-state`; WARN only (firmware-level) |
 | SYS-09 | `/dev/shm` mount options | WARN | `filesystem,mounts` | Requires `noexec,nosuid,nodev` |
 | SYS-10 | Ctrl-Alt-Delete masked | FAIL | `system` | `ctrl-alt-del.target` must be masked |
+| SYS-11 | Running kernel is the newest installed | FAIL | `updates,patching` | Compares `uname -r` against the newest `/boot/vmlinuz-*`. Reported next to SYS-03 despite the ID order, because it completes the same story |
+
+> **Why SYS-11 exists.** SYS-03 counts packages waiting to be installed. Once
+> `unattended-upgrades` installs a kernel, that count returns to zero while the
+> machine keeps executing the old image, because `Automatic-Reboot` defaults to
+> `"false"` and nothing activates the new one. The host then passes the patching
+> checks and remains exploitable. SYS-11 is the check that catches it, and its
+> remediation is a reboot, which no hardening role can perform safely on a
+> quorum cluster.
 
 ---
 

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -143,6 +143,11 @@ declare -A ANSIBLE_MAP=(
   ["SYS-08"]="secureboot|linux_secure_boot_rhel9|linux_secure_boot_ubuntu|Secure Boot verification"
   ["SYS-09"]="filesystem,mounts|linux_tmp_mounts_rhel9|linux_tmp_mounts_ubuntu|/dev/shm mount hardening"
   ["SYS-10"]="system|linux_ctrl_alt_del_rhel9|linux_ctrl_alt_del_ubuntu|Ctrl-Alt-Delete disabled"
+  # SYS-11: no role can fix this one. The remediation is a reboot, and on a quorum
+  # cluster a reboot is an orchestration problem, not a configuration one. The roles
+  # named here only decide who owns the reboot from now on (their *_reboot variable);
+  # they do not activate the kernel already sitting in /boot.
+  ["SYS-11"]="updates,patching|linux_dnf_automatic_rhel9|linux_unattended_upgrades_ubuntu|Reboot policy (does NOT activate the installed kernel)"
   ["AUTH-01"]="auth,users|linux_user_management_rhel9|linux_user_management_ubuntu|User management hardening"
   ["AUTH-02"]="auth,users|linux_user_management_rhel9|linux_user_management_ubuntu|User management hardening"
   # AUTH-03: PASS_MAX_DAYS in /etc/login.defs is set by user_management, not authselect
@@ -504,6 +509,40 @@ elif cmd_exists apt-get; then
     add_result "System" "FAIL" "SYS-03" "Pending updates" "Mises à jour en attente" "$PENDING package(s)" \
       "Appliquez: 'apt-get upgrade -y'"
   fi
+fi
+
+# SYS-11 Running kernel is the newest one installed
+#
+# Placed here rather than at the end of the section because it completes the
+# patching story SYS-03 starts; the ID is out of sequence so existing report
+# comparisons keep working.
+#
+# A kernel fix only takes effect once the machine boots into it. unattended-upgrades
+# installs the package and, with Automatic-Reboot "false" (the default), never
+# activates it. The host then reads as fully patched on disk while still executing
+# the vulnerable image, and SYS-03 cannot see it: there is nothing left pending to
+# count. Found on a 13-node estate where every host had a newer kernel in /boot and
+# seven had been running the old one for 108 days.
+KRUN=$(uname -r)
+KNEW=$(ls -1 /boot/vmlinuz-* 2>/dev/null | sed 's|.*/vmlinuz-||' | grep -vE '\.(sig|efi|signed|old)$' | sort -V | tail -1)
+KUP=$(awk '{printf "%d", $1/86400}' /proc/uptime 2>/dev/null || echo "?")
+if [[ -z "$KNEW" ]]; then
+  add_result "System" "WARN" "SYS-11" "Cannot determine installed kernels" "Noyaux installés indéterminés" \
+    "no /boot/vmlinuz-* found" \
+    "Comparez manuellement 'uname -r' au noyau installé le plus récent."
+elif [[ "$KNEW" == "$KRUN" ]]; then
+  add_result "System" "PASS" "SYS-11" "Running the newest installed kernel" "Noyau le plus récent actif" \
+    "$KRUN (uptime ${KUP}j)" ""
+elif [[ "$(printf '%s\n%s\n' "$KRUN" "$KNEW" | sort -V | tail -1)" == "$KRUN" ]]; then
+  # Running kernel outranks everything in /boot. Not a missing reboot: usually a
+  # custom or vendor kernel whose image lives outside /boot.
+  add_result "System" "WARN" "SYS-11" "Running kernel not found in /boot" "Noyau actif absent de /boot" \
+    "running $KRUN, newest in /boot $KNEW" \
+    "Noyau hors dépôt ou image hors /boot. Vérifiez que sa source livre bien les correctifs de sécurité."
+else
+  add_result "System" "FAIL" "SYS-11" "Newer kernel installed but not running" "Noyau plus récent installé mais inactif" \
+    "running $KRUN, installed $KNEW, uptime ${KUP}j" \
+    "Le correctif est installé mais inactif. Redémarrez pour activer $KNEW. Sur un cluster à quorum (OpenSearch, Kafka, etcd), un nœud à la fois en vérifiant la santé entre chaque."
 fi
 
 # SYS-04 SELinux / AppArmor

--- a/scripts/src/checks/sys.sh
+++ b/scripts/src/checks/sys.sh
@@ -37,6 +37,40 @@ elif cmd_exists apt-get; then
   fi
 fi
 
+# SYS-11 Running kernel is the newest one installed
+#
+# Placed here rather than at the end of the section because it completes the
+# patching story SYS-03 starts; the ID is out of sequence so existing report
+# comparisons keep working.
+#
+# A kernel fix only takes effect once the machine boots into it. unattended-upgrades
+# installs the package and, with Automatic-Reboot "false" (the default), never
+# activates it. The host then reads as fully patched on disk while still executing
+# the vulnerable image, and SYS-03 cannot see it: there is nothing left pending to
+# count. Found on a 13-node estate where every host had a newer kernel in /boot and
+# seven had been running the old one for 108 days.
+KRUN=$(uname -r)
+KNEW=$(ls -1 /boot/vmlinuz-* 2>/dev/null | sed 's|.*/vmlinuz-||' | grep -vE '\.(sig|efi|signed|old)$' | sort -V | tail -1)
+KUP=$(awk '{printf "%d", $1/86400}' /proc/uptime 2>/dev/null || echo "?")
+if [[ -z "$KNEW" ]]; then
+  add_result "System" "WARN" "SYS-11" "Cannot determine installed kernels" "Noyaux installés indéterminés" \
+    "no /boot/vmlinuz-* found" \
+    "Comparez manuellement 'uname -r' au noyau installé le plus récent."
+elif [[ "$KNEW" == "$KRUN" ]]; then
+  add_result "System" "PASS" "SYS-11" "Running the newest installed kernel" "Noyau le plus récent actif" \
+    "$KRUN (uptime ${KUP}j)" ""
+elif [[ "$(printf '%s\n%s\n' "$KRUN" "$KNEW" | sort -V | tail -1)" == "$KRUN" ]]; then
+  # Running kernel outranks everything in /boot. Not a missing reboot: usually a
+  # custom or vendor kernel whose image lives outside /boot.
+  add_result "System" "WARN" "SYS-11" "Running kernel not found in /boot" "Noyau actif absent de /boot" \
+    "running $KRUN, newest in /boot $KNEW" \
+    "Noyau hors dépôt ou image hors /boot. Vérifiez que sa source livre bien les correctifs de sécurité."
+else
+  add_result "System" "FAIL" "SYS-11" "Newer kernel installed but not running" "Noyau plus récent installé mais inactif" \
+    "running $KRUN, installed $KNEW, uptime ${KUP}j" \
+    "Le correctif est installé mais inactif. Redémarrez pour activer $KNEW. Sur un cluster à quorum (OpenSearch, Kafka, etcd), un nœud à la fois en vérifiant la santé entre chaque."
+fi
+
 # SYS-04 SELinux / AppArmor
 if cmd_exists getenforce; then
   SEMODE=$(getenforce 2>/dev/null || echo "Unknown")

--- a/scripts/src/lib/ansible_map.sh
+++ b/scripts/src/lib/ansible_map.sh
@@ -15,6 +15,11 @@ declare -A ANSIBLE_MAP=(
   ["SYS-08"]="secureboot|linux_secure_boot_rhel9|linux_secure_boot_ubuntu|Secure Boot verification"
   ["SYS-09"]="filesystem,mounts|linux_tmp_mounts_rhel9|linux_tmp_mounts_ubuntu|/dev/shm mount hardening"
   ["SYS-10"]="system|linux_ctrl_alt_del_rhel9|linux_ctrl_alt_del_ubuntu|Ctrl-Alt-Delete disabled"
+  # SYS-11: no role can fix this one. The remediation is a reboot, and on a quorum
+  # cluster a reboot is an orchestration problem, not a configuration one. The roles
+  # named here only decide who owns the reboot from now on (their *_reboot variable);
+  # they do not activate the kernel already sitting in /boot.
+  ["SYS-11"]="updates,patching|linux_dnf_automatic_rhel9|linux_unattended_upgrades_ubuntu|Reboot policy (does NOT activate the installed kernel)"
   ["AUTH-01"]="auth,users|linux_user_management_rhel9|linux_user_management_ubuntu|User management hardening"
   ["AUTH-02"]="auth,users|linux_user_management_rhel9|linux_user_management_ubuntu|User management hardening"
   # AUTH-03: PASS_MAX_DAYS in /etc/login.defs is set by user_management, not authselect


### PR DESCRIPTION
## The gap

SYS-03 counts packages waiting to be installed. "The fix is installed but not
in force" is a different quantity, and nothing in the suite measured it.

`unattended-upgrades` installs kernel security updates and, with
`Automatic-Reboot "false"` (the default), never activates them. The host reads
as patched on disk while still executing the vulnerable image. The pending
count says nothing, because nothing is pending any more.

## Found in the field

Running this against a 13-node estate:

| | |
|---|---|
| Hosts with a newer kernel in `/boot` than the one running | 13 of 13 |
| Hosts with `Automatic-Reboot "false"` | 13 of 13 |
| Hosts still executing 6.8.0-111 while 6.8.0-138 sat in `/boot` | 7 |
| Highest uptime | 108 days |

Verified on a real node:

```
❌ [FAIL] Newer kernel installed but not running
          running 6.8.0-111-generic, installed 6.8.0-138-generic, uptime 108j
```

To be precise about the gap: on that host SYS-03 also failed, but for an
unrelated reason (33 general pending packages). Had unattended-upgrades kept
everything current, SYS-03 would have read PASS with the 108-day-old kernel
still running. That is the case SYS-11 exists for.

## Implementation notes

Comparison uses `sort -V`, so `6.8.0-99` correctly ranks below `6.8.0-111`;
a lexicographic compare gets this backwards. Tested against six cases
including that trap, an empty `/boot`, and mismatched kernel flavours.

A running kernel that outranks everything in `/boot` is a WARN rather than a
FAIL: that is a vendor or custom kernel whose image lives elsewhere, not a
missed reboot.

The Ansible map entry is labelled as **not** fixing the condition. The
remediation is a reboot, and on a quorum cluster that is an orchestration
problem no hardening role can solve safely. Pretending otherwise is how a
remediation tool locks someone out of their own cluster.