### PR TITLE
fix: the inventory file is inventory/hosts, and always has been

### DIFF
--- a/ansible-hardening/playbooks/0_execute_full_pipeline.yml
+++ b/ansible-hardening/playbooks/0_execute_full_pipeline.yml
@@ -1,7 +1,7 @@
 ---
 # =============================================================================
 #  CyberAar | Main Playbook Orchestrator
-#  Run: ansible-playbook 0_execute_full_pipeline.yml -i inventory/hosts.yml
+#  Run: ansible-playbook 0_execute_full_pipeline.yml -i inventory/hosts
 # =============================================================================
 
 - name: "CyberAar | Step 1 — Pre-Hardening Baseline"

--- a/ansible-hardening/playbooks/2_configure_hardening.yml
+++ b/ansible-hardening/playbooks/2_configure_hardening.yml
@@ -22,26 +22,26 @@
 #    # 1. Dry-run against a single host (always start here)
 #    ANSIBLE_LOG_PATH=~/logs/$(date +%Y-%m-%d)-hardening.log \
 #    ansible-playbook --diff -u <admin_user> -b \
-#      -i inventory/hosts.yml \
+#      -i inventory/hosts \
 #      --extra-vars "target=my_test_server" \
 #      playbooks/2_configure_hardening.yml --tags hardening --check
 #
 #    # 2. Apply to a specific group
 #    ANSIBLE_LOG_PATH=~/logs/$(date +%Y-%m-%d)-hardening.log \
 #    ansible-playbook --diff -u <admin_user> -b \
-#      -i inventory/hosts.yml \
+#      -i inventory/hosts \
 #      --extra-vars "target=rhel_servers" \
 #      playbooks/2_configure_hardening.yml --tags hardening
 #
 #    # 3. Specific category only
 #    ansible-playbook --diff -u <admin_user> -b \
-#      -i inventory/hosts.yml \
+#      -i inventory/hosts \
 #      --extra-vars "target=my_test_server" \
 #      playbooks/2_configure_hardening.yml --tags ssh
 #
 #    # 4. Skip specific roles using disable vars (preferred over --skip-tags)
 #    ansible-playbook --diff -u <admin_user> -b \
-#      -i inventory/hosts.yml \
+#      -i inventory/hosts \
 #      --extra-vars "target=rhel_servers linux_bootloader_password_rhel9_disabled=true" \
 #      playbooks/2_configure_hardening.yml --tags hardening
 #

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -202,7 +202,7 @@ A self-contained single-file HTML report with:
       "fail_ids": ["AUTH-09", "NET-06", ...],
       "warn_ids": ["SYS-02", "AUTH-10", ...],
       "playbook": "playbooks/2_configure_hardening.yml",
-      "inventory": "inventory/hosts.yml"
+      "inventory": "inventory/hosts"
     }
   }
 }

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -56,7 +56,7 @@ Examples:
   cyberaar-baseline --host-file /etc/cyberaar/hosts.txt --user admin --output-dir /var/log/cyberaar
 
   # Fleet scan from Ansible inventory
-  cyberaar-baseline --inventory inventory/hosts.yml --user admin --output-dir /var/log/cyberaar
+  cyberaar-baseline --inventory inventory/hosts --user admin --output-dir /var/log/cyberaar
 
   # With Ansible remediation suggestions
   cyberaar-baseline --host 10.0.1.10 --ansible-dir ~/cyberaar-toolkit/ansible-hardening
@@ -1602,7 +1602,7 @@ _ansible_terminal_plan() {
     return
   fi
 
-  local _inv="-i inventory/hosts.yml"
+  local _inv="-i inventory/hosts"
   [[ -n "$ANSIBLE_INVENTORY" ]] && _inv="-i ${ANSIBLE_INVENTORY}"
   local _pb="playbooks/2_configure_hardening.yml"
   [[ -n "$ANSIBLE_DIR" ]] && _pb="${ANSIBLE_DIR}/playbooks/2_configure_hardening.yml"
@@ -1688,7 +1688,7 @@ _render_json() {
   local _j_host _j_os _j_inv
   _j_host=$(json_escape "$HOSTNAME_VAL")
   _j_os=$(json_escape "$OS_VAL")
-  _j_inv=$(json_escape "${ANSIBLE_INVENTORY:-inventory/hosts.yml}")
+  _j_inv=$(json_escape "${ANSIBLE_INVENTORY:-inventory/hosts}")
 
   cat > "$JSON_OUT" <<EOF
 {
@@ -1791,7 +1791,7 @@ _render_html() {
     html_plan_entries["$_tkey"]="$_entry"
   done
 
-  _inv_flag="inventory/hosts.yml"
+  _inv_flag="inventory/hosts"
   [[ -n "$ANSIBLE_INVENTORY" ]] && _inv_flag=$(html_escape "$ANSIBLE_INVENTORY")
   _pb="playbooks/2_configure_hardening.yml"
   [[ -n "$ANSIBLE_DIR" ]] && _pb="${ANSIBLE_DIR}/playbooks/2_configure_hardening.yml"

--- a/scripts/run-hardening.sh
+++ b/scripts/run-hardening.sh
@@ -23,7 +23,7 @@
 #
 #  Examples:
 #    # Connectivity test
-#    ansible -i inventory/hosts.yml linux_servers -m ping
+#    ansible -i inventory/hosts linux_servers -m ping
 #
 #    # Dry-run hardening only
 #    bash run-hardening.sh -u ubuntu -t ubuntu-vm-01 -c
@@ -82,7 +82,7 @@ search="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Pass 1: script is inside ansible-hardening/
 for _ in 1 2 3 4 5 6; do
-  if [[ -f "$search/inventory/hosts.yml" && -d "$search/playbooks" ]]; then
+  if [[ -f "$search/inventory/hosts" && -d "$search/playbooks" ]]; then
     ANSIBLE_BASE="$search"; break
   fi
   search="$(dirname "$search")"

--- a/scripts/src/main.sh
+++ b/scripts/src/main.sh
@@ -56,7 +56,7 @@ Examples:
   cyberaar-baseline --host-file /etc/cyberaar/hosts.txt --user admin --output-dir /var/log/cyberaar
 
   # Fleet scan from Ansible inventory
-  cyberaar-baseline --inventory inventory/hosts.yml --user admin --output-dir /var/log/cyberaar
+  cyberaar-baseline --inventory inventory/hosts --user admin --output-dir /var/log/cyberaar
 
   # With Ansible remediation suggestions
   cyberaar-baseline --host 10.0.1.10 --ansible-dir ~/cyberaar-toolkit/ansible-hardening

--- a/scripts/src/renderers/html.sh
+++ b/scripts/src/renderers/html.sh
@@ -71,7 +71,7 @@ _render_html() {
     html_plan_entries["$_tkey"]="$_entry"
   done
 
-  _inv_flag="inventory/hosts.yml"
+  _inv_flag="inventory/hosts"
   [[ -n "$ANSIBLE_INVENTORY" ]] && _inv_flag=$(html_escape "$ANSIBLE_INVENTORY")
   _pb="playbooks/2_configure_hardening.yml"
   [[ -n "$ANSIBLE_DIR" ]] && _pb="${ANSIBLE_DIR}/playbooks/2_configure_hardening.yml"

--- a/scripts/src/renderers/json.sh
+++ b/scripts/src/renderers/json.sh
@@ -25,7 +25,7 @@ _render_json() {
   local _j_host _j_os _j_inv
   _j_host=$(json_escape "$HOSTNAME_VAL")
   _j_os=$(json_escape "$OS_VAL")
-  _j_inv=$(json_escape "${ANSIBLE_INVENTORY:-inventory/hosts.yml}")
+  _j_inv=$(json_escape "${ANSIBLE_INVENTORY:-inventory/hosts}")
 
   cat > "$JSON_OUT" <<EOF
 {

--- a/scripts/src/renderers/terminal.sh
+++ b/scripts/src/renderers/terminal.sh
@@ -26,7 +26,7 @@ _ansible_terminal_plan() {
     return
   fi
 
-  local _inv="-i inventory/hosts.yml"
+  local _inv="-i inventory/hosts"
   [[ -n "$ANSIBLE_INVENTORY" ]] && _inv="-i ${ANSIBLE_INVENTORY}"
   local _pb="playbooks/2_configure_hardening.yml"
   [[ -n "$ANSIBLE_DIR" ]] && _pb="${ANSIBLE_DIR}/playbooks/2_configure_hardening.yml"


### PR DESCRIPTION
Twelve references across the repo point at `inventory/hosts.yml`. **That file has never existed.** The inventory is INI, at `ansible-hardening/inventory/hosts`.

Most are documentation. Two categories are not.

## The report told users to run a command that cannot work

The three renderers build the remediation command printed at the end of every audit — terminal output, HTML report and JSON export. All three emitted:

```
ansible-playbook -i inventory/hosts.yml ...
```

So the tool's own output handed the operator a path resolving to nothing. Anyone following the report's advice got an inventory-not-found error from Ansible and no clue why.

## A discovery branch that could never match

`run-hardening.sh` locates `ansible-hardening/` in two passes. Pass 1 handles the script sitting inside the collection directory, and tested:

```bash
[[ -f "$search/inventory/hosts.yml" && -d "$search/playbooks" ]]
```

Since `hosts.yml` does not exist, that was false at every level and the branch was dead. Running from inside `ansible-hardening/` fell through to Pass 2, which looks for a **nested** `ansible-hardening/`, found nothing, and died with "cannot find ansible-hardening/ (looked 6 levels up)" while standing in it.

Sources fixed and `cyberaar-baseline.sh` rebuilt from `src/` via `build.sh` rather than edited directly. Tests pass, 14 of 14.