### PR TITLE
feat(aartool): kernel attack surface, and a doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ together practitioners at home, across the diaspora and anywhere else, to build 
 
 | Deliverable | Description | Version |
 |-------------|-------------|---------|
-| `scripts/aartool` | One front door for the toolkit: `inspect` to audit, `plan` to preview hardening, `apply` to run it | v0.1.0 |
+| `scripts/aartool` | One front door: `inspect`, `plan`, `apply`, plus `surface` for kernel attack-surface reduction and `doctor` for preflight | v0.2.0 |
 | `scripts/cyberaar-baseline.sh` | Standalone bash script: audits a Linux server across 96 security checks, produces HTML + JSON reports with Ansible remediation plan | v4.2.0 |
 | `ansible-hardening/` | Ansible collection (`cyberaar.hardening`): 51 CIS-aligned hardening roles for RHEL 9 family and Ubuntu/Debian | v2.0.0 |
 | `execution-environment/` | Docker image: self-contained EE with Ansible + collection + playbooks, no local install required | `ghcr.io/cyberaar/ee-hardening` |
@@ -299,7 +299,55 @@ scripts/aartool plan --target ubuntu-vm-01 --user ubuntu --only ssh
 scripts/aartool apply --target ubuntu-vm-01 --user ubuntu
 ```
 
-Two things it does differently from what it wraps, both on purpose:
+### `aartool surface` — the window before the patch
+
+Red Hat and Debian ship the patch. Nothing helps you in the window *before* the
+patch exists, or on the machine you cannot reboot until the change window in
+three weeks. `surface` is for that window.
+
+```bash
+aartool surface              # what would the next kernel LPE still reach here?
+aartool surface --strict     # include mitigations that break real workloads
+aartool surface --fix        # print the sysctl drop-in that closes the gaps
+sudo aartool surface --apply # write it to /etc/sysctl.d and load it
+```
+
+These settings close **classes** of local privilege escalation rather than
+individual CVEs. Unprivileged user namespaces are the doorway a large share of
+published Linux LPEs walk through: they hand an unprivileged process
+`CAP_SYS_ADMIN` inside its own namespace, which is what turns a bug in nftables,
+io_uring or OverlayFS into root. Turning them off fixes none of those bugs. It
+removes the doorway they all use.
+
+Every mitigation states **what it costs**, and there are two tiers:
+
+| tier | meaning |
+|---|---|
+| `safe` | no mainstream workload is known to depend on it |
+| `strict` | will break something real for somebody, and the cost is printed |
+
+Only the safe tier runs by default. A tool that silently breaks your containers
+gets uninstalled, and then it protects nothing.
+
+Nothing here is compiled and nothing is rebooted. Everything applied lands in one
+drop-in file you can delete to revert. The same settings are audited as the
+`KRN-01`..`KRN-12` family in every baseline report, so the assessment and the
+remediation are two views of one thing — and a test asserts they cannot drift
+apart.
+
+### `aartool doctor`
+
+```bash
+aartool doctor                      # everything plan and apply depend on
+aartool doctor --target web-01      # also test SSH and sudo on that host
+```
+
+Exits non-zero if anything is missing, so it works as a CI gate. It exists
+because `ansible-playbook` failing halfway through with "couldn't resolve module
+ansible.posix.sysctl" tells an operator nothing about `ansible-galaxy`, and a
+half-applied hardening run is expensive.
+
+### Two things aartool does differently from what it wraps, both on purpose:
 
 **The dry run is a command, not a flag.** `run-hardening.sh` applies by default
 and takes `-c` to preview, so one missing character separates a report from a

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="0.1.0"
+AARTOOL_VERSION="0.2.0"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -56,6 +56,9 @@ Commands:
   inspect     Audit a machine and write HTML + JSON reports. Changes nothing.
   plan        Show what hardening would change on a target. Changes nothing.
   apply       Apply hardening to a target.
+  surface     Kernel attack surface: what a local privilege escalation
+              would still reach on this machine, and how to close it.
+  doctor      Check everything plan and apply depend on.
 
 Global options:
   -h, --help        Show this help, or help for a command
@@ -76,6 +79,9 @@ Examples:
 
   # Apply it. Asks you to confirm the target by name.
   aartool apply --target web-01 --user ubuntu
+
+  # What would the next kernel LPE still reach here?
+  aartool surface
 
 Run 'aartool <command> --help' for the options of a single command.
 EOF
@@ -156,6 +162,71 @@ target_in_inventory() {
   grep -qE "^\s*${target}(\s|$)" "$INVENTORY" && return 0
   grep -qE "^\s*\[${target}(:children)?\]\s*$" "$INVENTORY" && return 0
   return 1
+}
+
+# ── Kernel attack surface catalogue ──────────────────────────────────────────
+# One row per doorway. The KRN-xx family in the baseline audits these; this
+# catalogue is what makes them actionable, and it carries the two things an
+# audit result cannot: what the mitigation costs, and whether it is safe to
+# apply without knowing the workload.
+#
+# Fields, tab separated:
+#   id | sysctl key | desired value | tier | what it closes | what it costs
+#
+# tier is 'safe' or 'strict'. safe means no mainstream workload is known to
+# depend on it, so it can be applied on a server without a conversation.
+# strict means it will break something real for somebody, and the cost column
+# says what. Defaulting to safe is the difference between a tool people run and
+# a tool people uninstall after it takes down their containers.
+#
+# scripts/tests/test_aartool.sh asserts every id here has a matching KRN check,
+# so the catalogue and the audit cannot drift apart.
+
+surface_catalogue() {
+  cat <<'ROWS'
+KRN-02	kernel.unprivileged_bpf_disabled	1	safe	Unprivileged eBPF, a recurring source of kernel exploits	Nothing on a server. Some eBPF observability agents run privileged anyway.
+KRN-04	vm.unprivileged_userfaultfd	0	safe	userfaultfd, used to turn kernel races into reliable exploits	Nothing outside CRIU and some live-migration tooling.
+KRN-06	kernel.kexec_load_disabled	1	safe	Booting an arbitrary kernel without firmware, bypassing Secure Boot	Nothing, unless you use kdump crash capture.
+KRN-07	dev.tty.ldisc_autoload	0	safe	Autoloading old, lightly audited TTY line-discipline modules	Nothing on a server. Affects some serial and ham radio setups.
+KRN-09	net.core.bpf_jit_harden	2	safe	JIT-sprayed code in kernel memory	A small BPF throughput cost. Irrelevant unless you run XDP at line rate.
+KRN-10	kernel.sysrq	4	safe	Kernel operations from the physical console, including a memory dump	Loses SysRq except the keyboard reset combination.
+KRN-01	kernel.unprivileged_userns_clone	0	strict	The doorway most published Linux LPEs walk through	Breaks rootless Docker and Podman, Chrome's sandbox, and most CI runners.
+KRN-03	kernel.io_uring_disabled	2	strict	io_uring, young and disproportionately represented in recent LPEs	Breaks workloads that use it: some databases, proxies and modern async runtimes.
+KRN-05	kernel.modules_disabled	1	strict	Loading a rootkit as a kernel module	Irreversible until reboot. Blocks every later modprobe, including yours.
+ROWS
+}
+
+# Read a sysctl, printing '?' when the key does not exist on this kernel.
+surface_read() { sysctl -n "$1" 2>/dev/null || printf '?'; }
+
+# A key is satisfied if it already meets or exceeds the desired value. Several
+# of these are "higher is stricter", so an exact match would report a machine
+# that is MORE locked down than we ask as non-compliant.
+surface_ok() {
+  local key="$1" want="$2" have="$3"
+  [[ "$have" == "?" ]] && return 2          # not present on this kernel
+  case "$key" in
+    kernel.unprivileged_bpf_disabled|net.core.bpf_jit_harden|kernel.io_uring_disabled)
+      [[ "$have" =~ ^[0-9]+$ ]] && [[ "$have" -ge "$want" ]] ;;
+    kernel.sysrq)
+      # 0 is stricter than 4; anything else is permissive.
+      [[ "$have" == "0" || "$have" == "4" ]] ;;
+    user.max_user_namespaces|kernel.unprivileged_userns_clone|vm.unprivileged_userfaultfd)
+      [[ "$have" == "0" ]] ;;
+    *)
+      [[ "$have" == "$want" ]] ;;
+  esac
+}
+
+# Debian and Ubuntu expose the user namespace switch under a different key from
+# the RHEL family. Resolve it per machine rather than guessing from /etc/os-release,
+# which is wrong on derivatives.
+surface_userns_key() {
+  if [[ -e /proc/sys/kernel/unprivileged_userns_clone ]]; then
+    printf 'kernel.unprivileged_userns_clone'
+  else
+    printf 'user.max_user_namespaces'
+  fi
 }
 
 # ── inspect ──────────────────────────────────────────────────────────────────
@@ -328,6 +399,302 @@ cmd_harden() {
   bash "$HARDEN" "${args[@]}"
 }
 
+# ── surface ──────────────────────────────────────────────────────────────────
+# The command this toolkit exists to offer that a distribution vendor does not.
+#
+# Red Hat and Debian ship the patch. Nothing helps you in the window before the
+# patch exists, or on the machine you cannot reboot until the change window in
+# three weeks. These settings close classes of local privilege escalation rather
+# than individual CVEs, take effect immediately, and survive a kernel that is
+# still vulnerable.
+
+cmd_surface_usage() {
+  cat <<'EOF'
+aartool surface — kernel attack surface. Assess by default; changes nothing.
+
+Usage:
+  aartool surface [options]
+
+Options:
+      --strict          Include mitigations that break real workloads.
+                        Read the cost column first.
+      --fix             Print the sysctl drop-in that would close the gaps.
+                        Writes nothing.
+      --write FILE      Write that drop-in to FILE instead of printing it.
+      --apply           Write to /etc/sysctl.d/60-aartool-surface.conf and load
+                        it. Needs root. Asks for confirmation.
+  -y, --yes             Skip the confirmation on --apply.
+  -h, --help            Show this help
+
+Two tiers, because a mitigation that breaks the workload gets reverted and
+teaches people to ignore the tool:
+
+  safe      no mainstream workload is known to depend on it
+  strict    will break something real for somebody, and the cost is printed
+
+Without --strict, only the safe tier is considered.
+
+Every setting here is a sysctl. Nothing is compiled, nothing is rebooted, and
+anything applied can be undone by deleting the drop-in file and rebooting, or by
+setting the value back.
+EOF
+}
+
+cmd_surface() {
+  local strict=false emit="" out_file="" do_apply=false assume_yes=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --strict) strict=true; shift ;;
+      --fix)    emit="print"; shift ;;
+      --write)  [[ $# -ge 2 ]] || die "--write needs a file path."; emit="file"; out_file="$2"; shift 2 ;;
+      --apply)  do_apply=true; shift ;;
+      -y|--yes) assume_yes=true; shift ;;
+      -h|--help) cmd_surface_usage; return 0 ;;
+      --) shift; break ;;
+      -*) die "Unknown option for surface: $1. Try 'aartool surface --help'." ;;
+      *)  die "surface takes no positional arguments." ;;
+    esac
+  done
+
+  local tiers="safe"
+  [[ "$strict" == true ]] && tiers="safe strict"
+
+  local -a gap_key=() gap_val=() gap_id=() gap_cost=()
+  local n_ok=0 n_na=0
+
+  printf '\n%sKernel attack surface%s   %s\n' "$BOLD" "$RESET" "$(uname -r)"
+  printf '%s\n' "────────────────────────────────────────────────────────────────────"
+
+  local id key want tier closes cost have status
+  while IFS=$'\t' read -r id key want tier closes cost; do
+    [[ -n "$id" ]] || continue
+    case " $tiers " in *" $tier "*) ;; *) continue ;; esac
+
+    # The user namespace switch lives under a different key per distribution.
+    [[ "$id" == "KRN-01" ]] && key="$(surface_userns_key)"
+
+    have="$(surface_read "$key")"
+    if surface_ok "$key" "$want" "$have"; then
+      status="closed";  n_ok=$((n_ok+1))
+    elif [[ "$have" == "?" ]]; then
+      status="absent";  n_na=$((n_na+1))
+    else
+      status="OPEN"
+      gap_key+=("$key"); gap_val+=("$want"); gap_id+=("$id"); gap_cost+=("$cost")
+    fi
+
+    # A closed door is one line; an open one earns three, because the operator
+    # has a decision to make and needs the cost in front of them to make it.
+    case "$status" in
+      closed) printf '  %s✔%s  %-7s %s\n' "$GREEN" "$RESET" "$id" "$closes" ;;
+      absent) printf '  %s·%s  %-7s %s %s(not present on this kernel)%s\n' "$CYAN" "$RESET" "$id" "$closes" "$CYAN" "$RESET" ;;
+      OPEN)
+        printf '\n  %s✗%s  %-7s %s%s = %s%s\n' "$RED" "$RESET" "$id" "$BOLD" "$key" "$have" "$RESET"
+        printf '     %scloses%s  %s\n' "$CYAN" "$RESET" "$closes"
+        printf '     %scost%s    %s\n' "$CYAN" "$RESET" "$cost"
+        printf '     %sfix%s     %s = %s\n\n' "$CYAN" "$RESET" "$key" "$want" ;;
+    esac
+  done < <(surface_catalogue)
+
+  local n_gap="${#gap_key[@]}"
+  printf '%s\n' "────────────────────────────────────────────────────────────────────"
+  printf '  %d closed, %d open, %d not applicable' "$n_ok" "$n_gap" "$n_na"
+  [[ "$strict" == false ]] && printf '   %s(safe tier only; --strict for the rest)%s' "$CYAN" "$RESET"
+  printf '\n\n'
+
+  if [[ "$n_gap" -eq 0 ]]; then
+    success "Nothing to close in this tier."
+    return 0
+  fi
+
+  # Nothing below this point runs unless the operator asked for it.
+  [[ -z "$emit" && "$do_apply" == false ]] && {
+    info "Run 'aartool surface --fix' to see the drop-in that closes these, or --apply to apply it."
+    return 0
+  }
+
+  local dropin
+  dropin="$(surface_render_dropin gap_key gap_val gap_id)"
+
+  if [[ "$emit" == "print" ]]; then
+    printf '%s\n' "$dropin"
+    return 0
+  fi
+  if [[ "$emit" == "file" ]]; then
+    printf '%s\n' "$dropin" > "$out_file" || die "Cannot write $out_file"
+    success "Written: $out_file"
+    info "Apply with: sudo sysctl --system"
+    return 0
+  fi
+
+  # ── apply ──────────────────────────────────────────────────────────────────
+  [[ "${EUID:-$(id -u)}" -eq 0 ]] || die "--apply needs root. Re-run with sudo, or use --write and apply it yourself."
+
+  local target="/etc/sysctl.d/60-aartool-surface.conf"
+  printf '%sWill write%s %s and run sysctl --system\n' "$BOLD" "$RESET" "$target"
+  printf '%sClosing%s   %d setting(s)\n\n' "$BOLD" "$RESET" "$n_gap"
+
+  if [[ "$assume_yes" == false ]]; then
+    [[ -t 0 ]] || die "--apply needs confirmation and there is no terminal. Pass --yes if you meant it."
+    local answer=""
+    printf 'Apply these to this machine? Type yes to confirm: '
+    read -r answer
+    [[ "$answer" == "yes" ]] || die "Not confirmed. Nothing was changed."
+    echo
+  fi
+
+  printf '%s\n' "$dropin" > "$target" || die "Cannot write $target"
+  success "Wrote $target"
+  if sysctl --system >/dev/null 2>&1; then
+    success "Loaded. Verify with: aartool surface$( [[ "$strict" == true ]] && printf ' --strict' )"
+  else
+    warn "Wrote the file but 'sysctl --system' reported an error. Check: sysctl --system"
+  fi
+  info "To undo: rm $target && reboot (or set the values back by hand)."
+}
+
+# Rendered as a drop-in rather than applied with `sysctl -w`, so the change
+# survives a reboot and is visible in one file that can be deleted to revert.
+surface_render_dropin() {
+  local -n _k="$1" _v="$2" _i="$3"
+  printf '# Written by aartool %s on %s\n' "$AARTOOL_VERSION" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '#\n'
+  printf '# Kernel attack surface reduction. Each line closes a class of local\n'
+  printf '# privilege escalation rather than a single CVE, and takes effect without\n'
+  printf '# a reboot once loaded with: sysctl --system\n'
+  printf '#\n'
+  printf '# To revert: delete this file and reboot, or set the values back by hand.\n'
+  printf '\n'
+  local n="${#_k[@]}" idx
+  for (( idx=0; idx<n; idx++ )); do
+    printf '# %s\n%s = %s\n' "${_i[$idx]}" "${_k[$idx]}" "${_v[$idx]}"
+  done
+}
+
+# ── doctor ───────────────────────────────────────────────────────────────────
+# Everything that has to be true before plan or apply can work, checked in one
+# place and reported all at once.
+#
+# The failure this replaces: ansible-playbook exits with "couldn't resolve module
+# ansible.posix.sysctl" partway through a run, which tells the operator nothing
+# about ansible-galaxy and nothing about which of the two collections is
+# missing. Preflight is cheap; a half-applied hardening run is not.
+
+_doc_ok=0; _doc_bad=0
+_doc_pass() { printf '  %s✔%s  %-34s %s\n' "$GREEN" "$RESET" "$1" "${2:-}"; _doc_ok=$((_doc_ok+1)); }
+_doc_fail() {
+  printf '  %s✗%s  %-34s %s\n' "$RED" "$RESET" "$1" "${2:-}"
+  [[ -n "${3:-}" ]] && printf '     %sfix%s  %s\n' "$CYAN" "$RESET" "$3"
+  _doc_bad=$((_doc_bad+1))
+}
+_doc_warn() {
+  printf '  %s!%s  %-34s %s\n' "$YELLOW" "$RESET" "$1" "${2:-}"
+  [[ -n "${3:-}" ]] && printf '     %snote%s %s\n' "$CYAN" "$RESET" "$3"
+}
+
+cmd_doctor_usage() {
+  cat <<'EOF'
+aartool doctor — check everything plan and apply depend on. Changes nothing.
+
+Usage:
+  aartool doctor [--target HOST]
+
+Options:
+      --target HOST   Also test SSH reachability and sudo on that host
+  -h, --help          Show this help
+
+Exits non-zero if anything is missing, so it works as a CI gate.
+EOF
+}
+
+cmd_doctor() {
+  local target=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -t|--target) [[ $# -ge 2 ]] || die "$1 needs a value."; target="$2"; shift 2 ;;
+      -h|--help)   cmd_doctor_usage; return 0 ;;
+      -*) die "Unknown option for doctor: $1." ;;
+      *)  die "doctor takes no positional arguments." ;;
+    esac
+  done
+
+  resolve_paths
+  printf '\n%saartool doctor%s\n' "$BOLD" "$RESET"
+  printf '%s\n' "────────────────────────────────────────────────────────────────────"
+
+  # ── The toolkit itself ─────────────────────────────────────────────────────
+  _doc_pass "toolkit located" "$ANSIBLE_BASE"
+  [[ -r "$BASELINE" ]] && _doc_pass "cyberaar-baseline.sh" "readable" \
+    || _doc_fail "cyberaar-baseline.sh" "missing or unreadable" "Re-clone, or run: bash scripts/build.sh"
+  [[ -r "$HARDEN" ]] && _doc_pass "run-hardening.sh" "readable" \
+    || _doc_fail "run-hardening.sh" "missing or unreadable" "Re-clone the repository"
+
+  # ── Ansible ────────────────────────────────────────────────────────────────
+  if command -v ansible-playbook >/dev/null 2>&1; then
+    local av; av="$(ansible-playbook --version 2>/dev/null | head -1)"
+    _doc_pass "ansible-playbook" "${av:-present}"
+  else
+    _doc_fail "ansible-playbook" "not on PATH" "pip install ansible   (or use the container: see execution-environment/)"
+  fi
+
+  # Named individually. "install the collections" is not actionable when one of
+  # the two is already there and the other is not.
+  local req="$ANSIBLE_BASE/requirements.yml" c
+  if command -v ansible-galaxy >/dev/null 2>&1; then
+    for c in ansible.posix community.general; do
+      if ansible-galaxy collection list 2>/dev/null | grep -q "^${c} "; then
+        _doc_pass "collection ${c}" "installed"
+      else
+        _doc_fail "collection ${c}" "missing" "ansible-galaxy collection install -r ${req}"
+      fi
+    done
+  else
+    _doc_fail "ansible-galaxy" "not on PATH" "pip install ansible"
+  fi
+
+  # ── Inventory ──────────────────────────────────────────────────────────────
+  if [[ -f "$INVENTORY" ]]; then
+    local hosts; hosts="$(grep -cE '^[a-zA-Z0-9][a-zA-Z0-9._-]*' "$INVENTORY" 2>/dev/null || echo 0)"
+    _doc_pass "inventory" "$INVENTORY ($hosts entries)"
+  elif [[ -f "$INVENTORY_EXAMPLE" ]]; then
+    _doc_fail "inventory" "not created yet" "cp $INVENTORY_EXAMPLE $INVENTORY"
+  else
+    _doc_fail "inventory" "not found" "Create $INVENTORY in INI format"
+  fi
+
+  # ── The machine this is running on ─────────────────────────────────────────
+  local osname="unknown"
+  [[ -r /etc/os-release ]] && osname="$(. /etc/os-release 2>/dev/null; printf '%s %s' "${NAME:-?}" "${VERSION_ID:-}")"
+  _doc_pass "control node OS" "$osname"
+  _doc_pass "kernel" "$(uname -r)"
+
+  # ── Optional: can we actually reach the target ─────────────────────────────
+  if [[ -n "$target" ]]; then
+    if [[ ! -f "$INVENTORY" ]]; then
+      _doc_warn "target $target" "skipped" "No inventory to resolve it against"
+    elif ! target_in_inventory "$target"; then
+      _doc_fail "target $target" "not in inventory" "Add it to $INVENTORY"
+    elif ! command -v ansible >/dev/null 2>&1; then
+      _doc_warn "target $target" "skipped" "ansible not on PATH"
+    else
+      if ansible -i "$INVENTORY" "$target" -m ping >/dev/null 2>&1; then
+        _doc_pass "target $target" "reachable"
+      else
+        _doc_fail "target $target" "unreachable" "ansible -i $INVENTORY $target -m ping   (check SSH user and keys)"
+      fi
+    fi
+  fi
+
+  printf '%s\n' "────────────────────────────────────────────────────────────────────"
+  if [[ "$_doc_bad" -eq 0 ]]; then
+    printf '  %s%d checks passed. Ready.%s\n\n' "$GREEN" "$_doc_ok" "$RESET"
+    return 0
+  fi
+  printf '  %s%d problem(s)%s, %d fine. Fix the above and run doctor again.\n\n' "$RED" "$_doc_bad" "$RESET" "$_doc_ok"
+  return 1
+}
+
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 main() {
   [[ $# -gt 0 ]] || { usage; exit 1; }
@@ -336,6 +703,8 @@ main() {
     inspect)        shift; cmd_inspect "$@" ;;
     plan)           shift; cmd_harden plan  "$@" ;;
     apply)          shift; cmd_harden apply "$@" ;;
+    surface)        shift; cmd_surface "$@" ;;
+    doctor)         shift; cmd_doctor "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/aartool-src/cmd/doctor.sh
+++ b/scripts/aartool-src/cmd/doctor.sh
@@ -1,0 +1,122 @@
+# ── doctor ───────────────────────────────────────────────────────────────────
+# Everything that has to be true before plan or apply can work, checked in one
+# place and reported all at once.
+#
+# The failure this replaces: ansible-playbook exits with "couldn't resolve module
+# ansible.posix.sysctl" partway through a run, which tells the operator nothing
+# about ansible-galaxy and nothing about which of the two collections is
+# missing. Preflight is cheap; a half-applied hardening run is not.
+
+_doc_ok=0; _doc_bad=0
+_doc_pass() { printf '  %s✔%s  %-34s %s\n' "$GREEN" "$RESET" "$1" "${2:-}"; _doc_ok=$((_doc_ok+1)); }
+_doc_fail() {
+  printf '  %s✗%s  %-34s %s\n' "$RED" "$RESET" "$1" "${2:-}"
+  [[ -n "${3:-}" ]] && printf '     %sfix%s  %s\n' "$CYAN" "$RESET" "$3"
+  _doc_bad=$((_doc_bad+1))
+}
+_doc_warn() {
+  printf '  %s!%s  %-34s %s\n' "$YELLOW" "$RESET" "$1" "${2:-}"
+  [[ -n "${3:-}" ]] && printf '     %snote%s %s\n' "$CYAN" "$RESET" "$3"
+}
+
+cmd_doctor_usage() {
+  cat <<'EOF'
+aartool doctor — check everything plan and apply depend on. Changes nothing.
+
+Usage:
+  aartool doctor [--target HOST]
+
+Options:
+      --target HOST   Also test SSH reachability and sudo on that host
+  -h, --help          Show this help
+
+Exits non-zero if anything is missing, so it works as a CI gate.
+EOF
+}
+
+cmd_doctor() {
+  local target=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -t|--target) [[ $# -ge 2 ]] || die "$1 needs a value."; target="$2"; shift 2 ;;
+      -h|--help)   cmd_doctor_usage; return 0 ;;
+      -*) die "Unknown option for doctor: $1." ;;
+      *)  die "doctor takes no positional arguments." ;;
+    esac
+  done
+
+  resolve_paths
+  printf '\n%saartool doctor%s\n' "$BOLD" "$RESET"
+  printf '%s\n' "────────────────────────────────────────────────────────────────────"
+
+  # ── The toolkit itself ─────────────────────────────────────────────────────
+  _doc_pass "toolkit located" "$ANSIBLE_BASE"
+  [[ -r "$BASELINE" ]] && _doc_pass "cyberaar-baseline.sh" "readable" \
+    || _doc_fail "cyberaar-baseline.sh" "missing or unreadable" "Re-clone, or run: bash scripts/build.sh"
+  [[ -r "$HARDEN" ]] && _doc_pass "run-hardening.sh" "readable" \
+    || _doc_fail "run-hardening.sh" "missing or unreadable" "Re-clone the repository"
+
+  # ── Ansible ────────────────────────────────────────────────────────────────
+  if command -v ansible-playbook >/dev/null 2>&1; then
+    local av; av="$(ansible-playbook --version 2>/dev/null | head -1)"
+    _doc_pass "ansible-playbook" "${av:-present}"
+  else
+    _doc_fail "ansible-playbook" "not on PATH" "pip install ansible   (or use the container: see execution-environment/)"
+  fi
+
+  # Named individually. "install the collections" is not actionable when one of
+  # the two is already there and the other is not.
+  local req="$ANSIBLE_BASE/requirements.yml" c
+  if command -v ansible-galaxy >/dev/null 2>&1; then
+    for c in ansible.posix community.general; do
+      if ansible-galaxy collection list 2>/dev/null | grep -q "^${c} "; then
+        _doc_pass "collection ${c}" "installed"
+      else
+        _doc_fail "collection ${c}" "missing" "ansible-galaxy collection install -r ${req}"
+      fi
+    done
+  else
+    _doc_fail "ansible-galaxy" "not on PATH" "pip install ansible"
+  fi
+
+  # ── Inventory ──────────────────────────────────────────────────────────────
+  if [[ -f "$INVENTORY" ]]; then
+    local hosts; hosts="$(grep -cE '^[a-zA-Z0-9][a-zA-Z0-9._-]*' "$INVENTORY" 2>/dev/null || echo 0)"
+    _doc_pass "inventory" "$INVENTORY ($hosts entries)"
+  elif [[ -f "$INVENTORY_EXAMPLE" ]]; then
+    _doc_fail "inventory" "not created yet" "cp $INVENTORY_EXAMPLE $INVENTORY"
+  else
+    _doc_fail "inventory" "not found" "Create $INVENTORY in INI format"
+  fi
+
+  # ── The machine this is running on ─────────────────────────────────────────
+  local osname="unknown"
+  [[ -r /etc/os-release ]] && osname="$(. /etc/os-release 2>/dev/null; printf '%s %s' "${NAME:-?}" "${VERSION_ID:-}")"
+  _doc_pass "control node OS" "$osname"
+  _doc_pass "kernel" "$(uname -r)"
+
+  # ── Optional: can we actually reach the target ─────────────────────────────
+  if [[ -n "$target" ]]; then
+    if [[ ! -f "$INVENTORY" ]]; then
+      _doc_warn "target $target" "skipped" "No inventory to resolve it against"
+    elif ! target_in_inventory "$target"; then
+      _doc_fail "target $target" "not in inventory" "Add it to $INVENTORY"
+    elif ! command -v ansible >/dev/null 2>&1; then
+      _doc_warn "target $target" "skipped" "ansible not on PATH"
+    else
+      if ansible -i "$INVENTORY" "$target" -m ping >/dev/null 2>&1; then
+        _doc_pass "target $target" "reachable"
+      else
+        _doc_fail "target $target" "unreachable" "ansible -i $INVENTORY $target -m ping   (check SSH user and keys)"
+      fi
+    fi
+  fi
+
+  printf '%s\n' "────────────────────────────────────────────────────────────────────"
+  if [[ "$_doc_bad" -eq 0 ]]; then
+    printf '  %s%d checks passed. Ready.%s\n\n' "$GREEN" "$_doc_ok" "$RESET"
+    return 0
+  fi
+  printf '  %s%d problem(s)%s, %d fine. Fix the above and run doctor again.\n\n' "$RED" "$_doc_bad" "$RESET" "$_doc_ok"
+  return 1
+}

--- a/scripts/aartool-src/cmd/surface.sh
+++ b/scripts/aartool-src/cmd/surface.sh
@@ -1,0 +1,172 @@
+# ── surface ──────────────────────────────────────────────────────────────────
+# The command this toolkit exists to offer that a distribution vendor does not.
+#
+# Red Hat and Debian ship the patch. Nothing helps you in the window before the
+# patch exists, or on the machine you cannot reboot until the change window in
+# three weeks. These settings close classes of local privilege escalation rather
+# than individual CVEs, take effect immediately, and survive a kernel that is
+# still vulnerable.
+
+cmd_surface_usage() {
+  cat <<'EOF'
+aartool surface — kernel attack surface. Assess by default; changes nothing.
+
+Usage:
+  aartool surface [options]
+
+Options:
+      --strict          Include mitigations that break real workloads.
+                        Read the cost column first.
+      --fix             Print the sysctl drop-in that would close the gaps.
+                        Writes nothing.
+      --write FILE      Write that drop-in to FILE instead of printing it.
+      --apply           Write to /etc/sysctl.d/60-aartool-surface.conf and load
+                        it. Needs root. Asks for confirmation.
+  -y, --yes             Skip the confirmation on --apply.
+  -h, --help            Show this help
+
+Two tiers, because a mitigation that breaks the workload gets reverted and
+teaches people to ignore the tool:
+
+  safe      no mainstream workload is known to depend on it
+  strict    will break something real for somebody, and the cost is printed
+
+Without --strict, only the safe tier is considered.
+
+Every setting here is a sysctl. Nothing is compiled, nothing is rebooted, and
+anything applied can be undone by deleting the drop-in file and rebooting, or by
+setting the value back.
+EOF
+}
+
+cmd_surface() {
+  local strict=false emit="" out_file="" do_apply=false assume_yes=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --strict) strict=true; shift ;;
+      --fix)    emit="print"; shift ;;
+      --write)  [[ $# -ge 2 ]] || die "--write needs a file path."; emit="file"; out_file="$2"; shift 2 ;;
+      --apply)  do_apply=true; shift ;;
+      -y|--yes) assume_yes=true; shift ;;
+      -h|--help) cmd_surface_usage; return 0 ;;
+      --) shift; break ;;
+      -*) die "Unknown option for surface: $1. Try 'aartool surface --help'." ;;
+      *)  die "surface takes no positional arguments." ;;
+    esac
+  done
+
+  local tiers="safe"
+  [[ "$strict" == true ]] && tiers="safe strict"
+
+  local -a gap_key=() gap_val=() gap_id=() gap_cost=()
+  local n_ok=0 n_na=0
+
+  printf '\n%sKernel attack surface%s   %s\n' "$BOLD" "$RESET" "$(uname -r)"
+  printf '%s\n' "────────────────────────────────────────────────────────────────────"
+
+  local id key want tier closes cost have status
+  while IFS=$'\t' read -r id key want tier closes cost; do
+    [[ -n "$id" ]] || continue
+    case " $tiers " in *" $tier "*) ;; *) continue ;; esac
+
+    # The user namespace switch lives under a different key per distribution.
+    [[ "$id" == "KRN-01" ]] && key="$(surface_userns_key)"
+
+    have="$(surface_read "$key")"
+    if surface_ok "$key" "$want" "$have"; then
+      status="closed";  n_ok=$((n_ok+1))
+    elif [[ "$have" == "?" ]]; then
+      status="absent";  n_na=$((n_na+1))
+    else
+      status="OPEN"
+      gap_key+=("$key"); gap_val+=("$want"); gap_id+=("$id"); gap_cost+=("$cost")
+    fi
+
+    # A closed door is one line; an open one earns three, because the operator
+    # has a decision to make and needs the cost in front of them to make it.
+    case "$status" in
+      closed) printf '  %s✔%s  %-7s %s\n' "$GREEN" "$RESET" "$id" "$closes" ;;
+      absent) printf '  %s·%s  %-7s %s %s(not present on this kernel)%s\n' "$CYAN" "$RESET" "$id" "$closes" "$CYAN" "$RESET" ;;
+      OPEN)
+        printf '\n  %s✗%s  %-7s %s%s = %s%s\n' "$RED" "$RESET" "$id" "$BOLD" "$key" "$have" "$RESET"
+        printf '     %scloses%s  %s\n' "$CYAN" "$RESET" "$closes"
+        printf '     %scost%s    %s\n' "$CYAN" "$RESET" "$cost"
+        printf '     %sfix%s     %s = %s\n\n' "$CYAN" "$RESET" "$key" "$want" ;;
+    esac
+  done < <(surface_catalogue)
+
+  local n_gap="${#gap_key[@]}"
+  printf '%s\n' "────────────────────────────────────────────────────────────────────"
+  printf '  %d closed, %d open, %d not applicable' "$n_ok" "$n_gap" "$n_na"
+  [[ "$strict" == false ]] && printf '   %s(safe tier only; --strict for the rest)%s' "$CYAN" "$RESET"
+  printf '\n\n'
+
+  if [[ "$n_gap" -eq 0 ]]; then
+    success "Nothing to close in this tier."
+    return 0
+  fi
+
+  # Nothing below this point runs unless the operator asked for it.
+  [[ -z "$emit" && "$do_apply" == false ]] && {
+    info "Run 'aartool surface --fix' to see the drop-in that closes these, or --apply to apply it."
+    return 0
+  }
+
+  local dropin
+  dropin="$(surface_render_dropin gap_key gap_val gap_id)"
+
+  if [[ "$emit" == "print" ]]; then
+    printf '%s\n' "$dropin"
+    return 0
+  fi
+  if [[ "$emit" == "file" ]]; then
+    printf '%s\n' "$dropin" > "$out_file" || die "Cannot write $out_file"
+    success "Written: $out_file"
+    info "Apply with: sudo sysctl --system"
+    return 0
+  fi
+
+  # ── apply ──────────────────────────────────────────────────────────────────
+  [[ "${EUID:-$(id -u)}" -eq 0 ]] || die "--apply needs root. Re-run with sudo, or use --write and apply it yourself."
+
+  local target="/etc/sysctl.d/60-aartool-surface.conf"
+  printf '%sWill write%s %s and run sysctl --system\n' "$BOLD" "$RESET" "$target"
+  printf '%sClosing%s   %d setting(s)\n\n' "$BOLD" "$RESET" "$n_gap"
+
+  if [[ "$assume_yes" == false ]]; then
+    [[ -t 0 ]] || die "--apply needs confirmation and there is no terminal. Pass --yes if you meant it."
+    local answer=""
+    printf 'Apply these to this machine? Type yes to confirm: '
+    read -r answer
+    [[ "$answer" == "yes" ]] || die "Not confirmed. Nothing was changed."
+    echo
+  fi
+
+  printf '%s\n' "$dropin" > "$target" || die "Cannot write $target"
+  success "Wrote $target"
+  if sysctl --system >/dev/null 2>&1; then
+    success "Loaded. Verify with: aartool surface$( [[ "$strict" == true ]] && printf ' --strict' )"
+  else
+    warn "Wrote the file but 'sysctl --system' reported an error. Check: sysctl --system"
+  fi
+  info "To undo: rm $target && reboot (or set the values back by hand)."
+}
+
+# Rendered as a drop-in rather than applied with `sysctl -w`, so the change
+# survives a reboot and is visible in one file that can be deleted to revert.
+surface_render_dropin() {
+  local -n _k="$1" _v="$2" _i="$3"
+  printf '# Written by aartool %s on %s\n' "$AARTOOL_VERSION" "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '#\n'
+  printf '# Kernel attack surface reduction. Each line closes a class of local\n'
+  printf '# privilege escalation rather than a single CVE, and takes effect without\n'
+  printf '# a reboot once loaded with: sysctl --system\n'
+  printf '#\n'
+  printf '# To revert: delete this file and reboot, or set the values back by hand.\n'
+  printf '\n'
+  local n="${#_k[@]}" idx
+  for (( idx=0; idx<n; idx++ )); do
+    printf '# %s\n%s = %s\n' "${_i[$idx]}" "${_k[$idx]}" "${_v[$idx]}"
+  done
+}

--- a/scripts/aartool-src/lib/surface.sh
+++ b/scripts/aartool-src/lib/surface.sh
@@ -1,0 +1,64 @@
+# ── Kernel attack surface catalogue ──────────────────────────────────────────
+# One row per doorway. The KRN-xx family in the baseline audits these; this
+# catalogue is what makes them actionable, and it carries the two things an
+# audit result cannot: what the mitigation costs, and whether it is safe to
+# apply without knowing the workload.
+#
+# Fields, tab separated:
+#   id | sysctl key | desired value | tier | what it closes | what it costs
+#
+# tier is 'safe' or 'strict'. safe means no mainstream workload is known to
+# depend on it, so it can be applied on a server without a conversation.
+# strict means it will break something real for somebody, and the cost column
+# says what. Defaulting to safe is the difference between a tool people run and
+# a tool people uninstall after it takes down their containers.
+#
+# scripts/tests/test_aartool.sh asserts every id here has a matching KRN check,
+# so the catalogue and the audit cannot drift apart.
+
+surface_catalogue() {
+  cat <<'ROWS'
+KRN-02	kernel.unprivileged_bpf_disabled	1	safe	Unprivileged eBPF, a recurring source of kernel exploits	Nothing on a server. Some eBPF observability agents run privileged anyway.
+KRN-04	vm.unprivileged_userfaultfd	0	safe	userfaultfd, used to turn kernel races into reliable exploits	Nothing outside CRIU and some live-migration tooling.
+KRN-06	kernel.kexec_load_disabled	1	safe	Booting an arbitrary kernel without firmware, bypassing Secure Boot	Nothing, unless you use kdump crash capture.
+KRN-07	dev.tty.ldisc_autoload	0	safe	Autoloading old, lightly audited TTY line-discipline modules	Nothing on a server. Affects some serial and ham radio setups.
+KRN-09	net.core.bpf_jit_harden	2	safe	JIT-sprayed code in kernel memory	A small BPF throughput cost. Irrelevant unless you run XDP at line rate.
+KRN-10	kernel.sysrq	4	safe	Kernel operations from the physical console, including a memory dump	Loses SysRq except the keyboard reset combination.
+KRN-01	kernel.unprivileged_userns_clone	0	strict	The doorway most published Linux LPEs walk through	Breaks rootless Docker and Podman, Chrome's sandbox, and most CI runners.
+KRN-03	kernel.io_uring_disabled	2	strict	io_uring, young and disproportionately represented in recent LPEs	Breaks workloads that use it: some databases, proxies and modern async runtimes.
+KRN-05	kernel.modules_disabled	1	strict	Loading a rootkit as a kernel module	Irreversible until reboot. Blocks every later modprobe, including yours.
+ROWS
+}
+
+# Read a sysctl, printing '?' when the key does not exist on this kernel.
+surface_read() { sysctl -n "$1" 2>/dev/null || printf '?'; }
+
+# A key is satisfied if it already meets or exceeds the desired value. Several
+# of these are "higher is stricter", so an exact match would report a machine
+# that is MORE locked down than we ask as non-compliant.
+surface_ok() {
+  local key="$1" want="$2" have="$3"
+  [[ "$have" == "?" ]] && return 2          # not present on this kernel
+  case "$key" in
+    kernel.unprivileged_bpf_disabled|net.core.bpf_jit_harden|kernel.io_uring_disabled)
+      [[ "$have" =~ ^[0-9]+$ ]] && [[ "$have" -ge "$want" ]] ;;
+    kernel.sysrq)
+      # 0 is stricter than 4; anything else is permissive.
+      [[ "$have" == "0" || "$have" == "4" ]] ;;
+    user.max_user_namespaces|kernel.unprivileged_userns_clone|vm.unprivileged_userfaultfd)
+      [[ "$have" == "0" ]] ;;
+    *)
+      [[ "$have" == "$want" ]] ;;
+  esac
+}
+
+# Debian and Ubuntu expose the user namespace switch under a different key from
+# the RHEL family. Resolve it per machine rather than guessing from /etc/os-release,
+# which is wrong on derivatives.
+surface_userns_key() {
+  if [[ -e /proc/sys/kernel/unprivileged_userns_clone ]]; then
+    printf 'kernel.unprivileged_userns_clone'
+  else
+    printf 'user.max_user_namespaces'
+  fi
+}

--- a/scripts/aartool-src/main.sh
+++ b/scripts/aartool-src/main.sh
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="0.1.0"
+AARTOOL_VERSION="0.2.0"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -56,6 +56,9 @@ Commands:
   inspect     Audit a machine and write HTML + JSON reports. Changes nothing.
   plan        Show what hardening would change on a target. Changes nothing.
   apply       Apply hardening to a target.
+  surface     Kernel attack surface: what a local privilege escalation
+              would still reach on this machine, and how to close it.
+  doctor      Check everything plan and apply depend on.
 
 Global options:
   -h, --help        Show this help, or help for a command
@@ -76,6 +79,9 @@ Examples:
 
   # Apply it. Asks you to confirm the target by name.
   aartool apply --target web-01 --user ubuntu
+
+  # What would the next kernel LPE still reach here?
+  aartool surface
 
 Run 'aartool <command> --help' for the options of a single command.
 EOF

--- a/scripts/aartool-src/run.sh
+++ b/scripts/aartool-src/run.sh
@@ -6,6 +6,8 @@ main() {
     inspect)        shift; cmd_inspect "$@" ;;
     plan)           shift; cmd_harden plan  "$@" ;;
     apply)          shift; cmd_harden apply "$@" ;;
+    surface)        shift; cmd_surface "$@" ;;
+    doctor)         shift; cmd_doctor "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/build-aartool.sh
+++ b/scripts/build-aartool.sh
@@ -16,8 +16,11 @@ OUT="${SCRIPT_DIR}/aartool"
 PARTS=(
   aartool-src/main.sh
   aartool-src/lib/paths.sh
+  aartool-src/lib/surface.sh
   aartool-src/cmd/inspect.sh
   aartool-src/cmd/harden.sh
+  aartool-src/cmd/surface.sh
+  aartool-src/cmd/doctor.sh
   aartool-src/run.sh
 )
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,6 +17,7 @@ PARTS=(
   src/lib/remote.sh
   src/lib/core.sh
   src/checks/sys.sh
+  src/checks/kernel.sh
   src/checks/auth.sh
   src/checks/ssh.sh
   src/checks/fs.sh

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -641,6 +641,230 @@ else
 fi
 }
 
+# =============================================================================
+#  KERNEL ATTACK SURFACE  (KRN-01 .. KRN-12)
+#
+#  WHY THIS FAMILY EXISTS
+#  Every other family here asks "is this configured correctly". This one asks a
+#  different question: "when the next local privilege escalation lands, does it
+#  reach you".
+#
+#  Red Hat and Debian ship the patch. Nobody helps with the window before the
+#  patch exists, or with the machine you cannot reboot this quarter. That window
+#  is the whole point of these checks: each one closes a class of exploit rather
+#  than a single CVE, and each takes effect without a reboot.
+#
+#  A worked example, so the framing is not marketing. Unprivileged user
+#  namespaces are the entry point for a large share of published Linux LPEs:
+#  they hand an unprivileged process CAP_SYS_ADMIN inside its own namespace,
+#  which is what turns a bug in nftables, io_uring, OverlayFS or a network
+#  protocol into root. Turning them off does not fix any of those bugs. It
+#  removes the doorway they all walk through.
+#
+#  These are WARN, not FAIL, and deliberately. Several of them break real
+#  workloads: containers need user namespaces, some databases want io_uring,
+#  debuggers want ptrace. A tool that fails a build over a setting the workload
+#  requires teaches people to ignore it. Each check says what it costs.
+# =============================================================================
+
+_krn_sysctl() { sysctl -n "$1" 2>/dev/null || printf '?'; }
+
+# The summary at KRN-12 counts these rather than re-testing the values. An
+# earlier version evaluated the sysctls a second time and disagreed with itself:
+# KRN-02 passed on unprivileged_bpf_disabled=2 while the summary, matching only
+# "1", counted the same setting as an open door. A summary derived from anything
+# other than the verdicts it summarises will drift from them.
+_KRN_DOORS_OPEN=0
+_KRN_DOORS_KNOWN=0
+_krn_door() {           # _krn_door open|closed|na
+  case "$1" in
+    open)   _KRN_DOORS_OPEN=$((_KRN_DOORS_OPEN+1)); _KRN_DOORS_KNOWN=$((_KRN_DOORS_KNOWN+1)) ;;
+    closed) _KRN_DOORS_KNOWN=$((_KRN_DOORS_KNOWN+1)) ;;
+  esac
+}
+
+# ── KRN-01  Unprivileged user namespaces ─────────────────────────────────────
+# The single highest-value setting in this family.
+_KRN_USERNS="?"
+if [[ -r /proc/sys/kernel/unprivileged_userns_clone ]]; then
+  _KRN_USERNS="$(_krn_sysctl kernel.unprivileged_userns_clone)"   # Debian/Ubuntu
+  if [[ "$_KRN_USERNS" == "0" ]]; then
+    add_result "Kernel" "PASS" "KRN-01" "Unprivileged user namespaces disabled" \
+      "Espaces de noms utilisateur non privilégiés désactivés" "unprivileged_userns_clone=0" ""
+    _krn_door closed
+  else
+    add_result "Kernel" "WARN" "KRN-01" "Unprivileged user namespaces allowed" \
+      "Espaces de noms utilisateur non privilégiés autorisés" "unprivileged_userns_clone=$_KRN_USERNS" \
+      "Porte d'entrée de nombreuses élévations de privilèges locales. 'sysctl -w kernel.unprivileged_userns_clone=0'. Casse Docker/Podman rootless et le bac à sable de Chrome."
+    _krn_door open
+  fi
+else
+  _KRN_USERNS="$(_krn_sysctl user.max_user_namespaces)"            # RHEL family
+  if [[ "$_KRN_USERNS" == "0" ]]; then
+    add_result "Kernel" "PASS" "KRN-01" "Unprivileged user namespaces disabled" \
+      "Espaces de noms utilisateur non privilégiés désactivés" "user.max_user_namespaces=0" ""
+    _krn_door closed
+  elif [[ "$_KRN_USERNS" == "?" ]]; then
+    add_result "Kernel" "WARN" "KRN-01" "Cannot determine user namespace policy" \
+      "Politique des espaces de noms indéterminée" "no unprivileged_userns_clone or max_user_namespaces" ""
+    _krn_door na
+  else
+    add_result "Kernel" "WARN" "KRN-01" "Unprivileged user namespaces allowed" \
+      "Espaces de noms utilisateur non privilégiés autorisés" "user.max_user_namespaces=$_KRN_USERNS" \
+      "Porte d'entrée de nombreuses élévations de privilèges locales. 'sysctl -w user.max_user_namespaces=0'. Casse les conteneurs rootless."
+    _krn_door open
+  fi
+fi
+
+# ── KRN-02  Unprivileged eBPF ────────────────────────────────────────────────
+_KRN_BPF="$(_krn_sysctl kernel.unprivileged_bpf_disabled)"
+case "$_KRN_BPF" in
+  1|2) add_result "Kernel" "PASS" "KRN-02" "Unprivileged eBPF disabled" \
+         "eBPF non privilégié désactivé" "unprivileged_bpf_disabled=$_KRN_BPF" ""
+       _krn_door closed ;;
+  "?") add_result "Kernel" "WARN" "KRN-02" "eBPF policy not readable" \
+         "Politique eBPF illisible" "kernel.unprivileged_bpf_disabled absent" ""
+       _krn_door na ;;
+  *)   add_result "Kernel" "WARN" "KRN-02" "Unprivileged eBPF allowed" \
+         "eBPF non privilégié autorisé" "unprivileged_bpf_disabled=$_KRN_BPF" \
+         "Le vérificateur eBPF est une surface d'exploitation récurrente. 'sysctl -w kernel.unprivileged_bpf_disabled=1'"
+       _krn_door open ;;
+esac
+
+# ── KRN-03  io_uring ─────────────────────────────────────────────────────────
+# Young, large and fast-moving: a disproportionate share of recent LPEs.
+_KRN_URING="$(_krn_sysctl kernel.io_uring_disabled)"
+if [[ "$_KRN_URING" == "?" ]]; then
+  add_result "Kernel" "PASS" "KRN-03" "io_uring control not present" \
+    "Contrôle io_uring absent" "kernel.io_uring_disabled unsupported on this kernel" ""
+  _krn_door na
+elif [[ "$_KRN_URING" == "2" ]]; then
+  add_result "Kernel" "PASS" "KRN-03" "io_uring disabled" "io_uring désactivé" "io_uring_disabled=2" ""
+  _krn_door closed
+else
+  add_result "Kernel" "WARN" "KRN-03" "io_uring available to unprivileged users" \
+    "io_uring accessible sans privilège" "io_uring_disabled=$_KRN_URING" \
+    "Sous-système jeune et très exposé. 'sysctl -w kernel.io_uring_disabled=2' (1 = réservé au groupe io_uring_group). Peut affecter certaines bases de données et proxys."
+  _krn_door open
+fi
+
+# ── KRN-04  userfaultfd ──────────────────────────────────────────────────────
+# Not itself a bug, but what turns a race into a reliable exploit.
+_KRN_UFFD="$(_krn_sysctl vm.unprivileged_userfaultfd)"
+if [[ "$_KRN_UFFD" == "0" ]]; then
+  add_result "Kernel" "PASS" "KRN-04" "Unprivileged userfaultfd disabled" \
+    "userfaultfd non privilégié désactivé" "vm.unprivileged_userfaultfd=0" ""
+  _krn_door closed
+elif [[ "$_KRN_UFFD" == "?" ]]; then
+  add_result "Kernel" "PASS" "KRN-04" "userfaultfd control not present" \
+    "Contrôle userfaultfd absent" "vm.unprivileged_userfaultfd unsupported" ""
+  _krn_door na
+else
+  add_result "Kernel" "WARN" "KRN-04" "Unprivileged userfaultfd allowed" \
+    "userfaultfd non privilégié autorisé" "vm.unprivileged_userfaultfd=$_KRN_UFFD" \
+    "Utilisé pour fiabiliser l'exploitation des conditions de course noyau. 'sysctl -w vm.unprivileged_userfaultfd=0'"
+  _krn_door open
+fi
+
+# ── KRN-05  Kernel module loading ────────────────────────────────────────────
+_KRN_MODLOCK="$(_krn_sysctl kernel.modules_disabled)"
+if [[ "$_KRN_MODLOCK" == "1" ]]; then
+  add_result "Kernel" "PASS" "KRN-05" "Module loading locked" "Chargement de modules verrouillé" "kernel.modules_disabled=1" ""
+else
+  add_result "Kernel" "WARN" "KRN-05" "Module loading open" "Chargement de modules ouvert" "kernel.modules_disabled=${_KRN_MODLOCK/\?/0}" \
+    "Verrouiller après le démarrage empêche le chargement d'un rootkit en module. 'sysctl -w kernel.modules_disabled=1' une fois la machine stabilisée. Irréversible jusqu'au redémarrage."
+fi
+
+# ── KRN-06  kexec ────────────────────────────────────────────────────────────
+_KRN_KEXEC="$(_krn_sysctl kernel.kexec_load_disabled)"
+if [[ "$_KRN_KEXEC" == "1" ]]; then
+  add_result "Kernel" "PASS" "KRN-06" "kexec disabled" "kexec désactivé" "kexec_load_disabled=1" ""
+else
+  add_result "Kernel" "WARN" "KRN-06" "kexec allowed" "kexec autorisé" "kexec_load_disabled=${_KRN_KEXEC/\?/0}" \
+    "kexec permet de démarrer un noyau arbitraire sans passer par le firmware, contournant Secure Boot. 'sysctl -w kernel.kexec_load_disabled=1'"
+fi
+
+# ── KRN-07  TTY line discipline autoload ─────────────────────────────────────
+_KRN_LDISC="$(_krn_sysctl dev.tty.ldisc_autoload)"
+if [[ "$_KRN_LDISC" == "0" ]]; then
+  add_result "Kernel" "PASS" "KRN-07" "TTY line discipline autoload disabled" \
+    "Chargement auto des disciplines TTY désactivé" "dev.tty.ldisc_autoload=0" ""
+elif [[ "$_KRN_LDISC" == "?" ]]; then
+  add_result "Kernel" "PASS" "KRN-07" "ldisc autoload control not present" \
+    "Contrôle ldisc absent" "dev.tty.ldisc_autoload unsupported" ""
+else
+  add_result "Kernel" "WARN" "KRN-07" "TTY line discipline autoload enabled" \
+    "Chargement auto des disciplines TTY activé" "dev.tty.ldisc_autoload=$_KRN_LDISC" \
+    "Permet à un utilisateur non privilégié de charger des modules TTY anciens et peu audités. 'sysctl -w dev.tty.ldisc_autoload=0'"
+fi
+
+# ── KRN-08  Kernel lockdown ──────────────────────────────────────────────────
+if [[ -r /sys/kernel/security/lockdown ]]; then
+  _KRN_LOCKDOWN="$(sed -n 's/.*\[\([a-z]*\)\].*/\1/p' /sys/kernel/security/lockdown 2>/dev/null)"
+  case "$_KRN_LOCKDOWN" in
+    integrity|confidentiality)
+      add_result "Kernel" "PASS" "KRN-08" "Kernel lockdown active" "Verrouillage noyau actif" "lockdown=$_KRN_LOCKDOWN" "" ;;
+    *)
+      add_result "Kernel" "WARN" "KRN-08" "Kernel lockdown off" "Verrouillage noyau inactif" "lockdown=${_KRN_LOCKDOWN:-none}" \
+        "Empêche même root de modifier le noyau en cours d'exécution. S'active via Secure Boot ou 'lockdown=integrity' sur la ligne de commande du noyau." ;;
+  esac
+else
+  add_result "Kernel" "WARN" "KRN-08" "Kernel lockdown not available" "Verrouillage noyau indisponible" \
+    "/sys/kernel/security/lockdown absent" "Nécessite un noyau compilé avec CONFIG_SECURITY_LOCKDOWN_LSM."
+fi
+
+# ── KRN-09  BPF JIT hardening ────────────────────────────────────────────────
+_KRN_JIT="$(_krn_sysctl net.core.bpf_jit_harden)"
+if [[ "$_KRN_JIT" =~ ^[12]$ ]]; then
+  add_result "Kernel" "PASS" "KRN-09" "BPF JIT hardening on" "Durcissement JIT BPF actif" "bpf_jit_harden=$_KRN_JIT" ""
+elif [[ "$_KRN_JIT" == "?" ]]; then
+  add_result "Kernel" "PASS" "KRN-09" "BPF JIT control not present" "Contrôle JIT BPF absent" "net.core.bpf_jit_harden unsupported" ""
+else
+  add_result "Kernel" "WARN" "KRN-09" "BPF JIT hardening off" "Durcissement JIT BPF inactif" "bpf_jit_harden=$_KRN_JIT" \
+    "Sans durcissement, le JIT facilite la pulvérisation de code en mémoire noyau. 'sysctl -w net.core.bpf_jit_harden=2'"
+fi
+
+# ── KRN-10  SysRq ────────────────────────────────────────────────────────────
+_KRN_SYSRQ="$(_krn_sysctl kernel.sysrq)"
+if [[ "$_KRN_SYSRQ" == "0" || "$_KRN_SYSRQ" == "4" ]]; then
+  add_result "Kernel" "PASS" "KRN-10" "SysRq restricted" "SysRq restreint" "kernel.sysrq=$_KRN_SYSRQ" ""
+else
+  add_result "Kernel" "WARN" "KRN-10" "SysRq permissive" "SysRq permissif" "kernel.sysrq=${_KRN_SYSRQ/\?/unknown}" \
+    "SysRq expose des opérations noyau depuis la console physique, dont un vidage mémoire. 'sysctl -w kernel.sysrq=0' (4 conserve seulement le rappel clavier)."
+fi
+
+# ── KRN-11  Exotic filesystem modules ────────────────────────────────────────
+# Rarely used, rarely audited, historically a steady source of CVEs. Reached by
+# anyone who can plug in a USB stick or mount an image.
+_KRN_FS_LOADED=""
+for _m in cramfs freevxfs jffs2 hfs hfsplus squashfs udf ksmbd; do
+  lsmod 2>/dev/null | awk '{print $1}' | grep -qx "$_m" && _KRN_FS_LOADED+="$_m "
+done
+if [[ -z "$_KRN_FS_LOADED" ]]; then
+  add_result "Kernel" "PASS" "KRN-11" "No exotic filesystem modules loaded" \
+    "Aucun module de système de fichiers exotique chargé" "cramfs/freevxfs/jffs2/hfs/hfsplus/udf/ksmbd absent" ""
+else
+  add_result "Kernel" "WARN" "KRN-11" "Exotic filesystem modules loaded" \
+    "Modules de systèmes de fichiers exotiques chargés" "loaded: ${_KRN_FS_LOADED% }" \
+    "Peu utilisés, peu audités, source régulière de CVE. Ajoutez 'install <module> /bin/true' dans /etc/modprobe.d/ pour ceux dont vous n'avez pas besoin."
+fi
+
+# ── KRN-12  Exposure summary ─────────────────────────────────────────────────
+# The point of the family, stated once: how many doorways are still open.
+# Counts the verdicts recorded above; it does not re-read a single sysctl.
+if [[ "$_KRN_DOORS_KNOWN" -eq 0 ]]; then
+  add_result "Kernel" "WARN" "KRN-12" "LPE doorway status unknown" \
+    "État des portes d'élévation inconnu" "no doorway control readable on this kernel" ""
+elif [[ "$_KRN_DOORS_OPEN" -eq 0 ]]; then
+  add_result "Kernel" "PASS" "KRN-12" "Primary LPE doorways closed" \
+    "Principales portes d'élévation fermées" "$_KRN_DOORS_KNOWN of $_KRN_DOORS_KNOWN closed" ""
+else
+  add_result "Kernel" "WARN" "KRN-12" "Primary LPE doorways open" \
+    "Principales portes d'élévation ouvertes" \
+    "$_KRN_DOORS_OPEN of $_KRN_DOORS_KNOWN open (userns, eBPF, io_uring, userfaultfd)" \
+    "Ces réglages neutralisent des classes entières d'exploits, sans correctif et sans redémarrage. Voir 'aartool surface'."
+fi
+
 _checks_auth() {
 # =============================================================================
 #  2. AUTHENTICATION & ACCESS

--- a/scripts/src/checks/kernel.sh
+++ b/scripts/src/checks/kernel.sh
@@ -1,0 +1,223 @@
+# =============================================================================
+#  KERNEL ATTACK SURFACE  (KRN-01 .. KRN-12)
+#
+#  WHY THIS FAMILY EXISTS
+#  Every other family here asks "is this configured correctly". This one asks a
+#  different question: "when the next local privilege escalation lands, does it
+#  reach you".
+#
+#  Red Hat and Debian ship the patch. Nobody helps with the window before the
+#  patch exists, or with the machine you cannot reboot this quarter. That window
+#  is the whole point of these checks: each one closes a class of exploit rather
+#  than a single CVE, and each takes effect without a reboot.
+#
+#  A worked example, so the framing is not marketing. Unprivileged user
+#  namespaces are the entry point for a large share of published Linux LPEs:
+#  they hand an unprivileged process CAP_SYS_ADMIN inside its own namespace,
+#  which is what turns a bug in nftables, io_uring, OverlayFS or a network
+#  protocol into root. Turning them off does not fix any of those bugs. It
+#  removes the doorway they all walk through.
+#
+#  These are WARN, not FAIL, and deliberately. Several of them break real
+#  workloads: containers need user namespaces, some databases want io_uring,
+#  debuggers want ptrace. A tool that fails a build over a setting the workload
+#  requires teaches people to ignore it. Each check says what it costs.
+# =============================================================================
+
+_krn_sysctl() { sysctl -n "$1" 2>/dev/null || printf '?'; }
+
+# The summary at KRN-12 counts these rather than re-testing the values. An
+# earlier version evaluated the sysctls a second time and disagreed with itself:
+# KRN-02 passed on unprivileged_bpf_disabled=2 while the summary, matching only
+# "1", counted the same setting as an open door. A summary derived from anything
+# other than the verdicts it summarises will drift from them.
+_KRN_DOORS_OPEN=0
+_KRN_DOORS_KNOWN=0
+_krn_door() {           # _krn_door open|closed|na
+  case "$1" in
+    open)   _KRN_DOORS_OPEN=$((_KRN_DOORS_OPEN+1)); _KRN_DOORS_KNOWN=$((_KRN_DOORS_KNOWN+1)) ;;
+    closed) _KRN_DOORS_KNOWN=$((_KRN_DOORS_KNOWN+1)) ;;
+  esac
+}
+
+# ── KRN-01  Unprivileged user namespaces ─────────────────────────────────────
+# The single highest-value setting in this family.
+_KRN_USERNS="?"
+if [[ -r /proc/sys/kernel/unprivileged_userns_clone ]]; then
+  _KRN_USERNS="$(_krn_sysctl kernel.unprivileged_userns_clone)"   # Debian/Ubuntu
+  if [[ "$_KRN_USERNS" == "0" ]]; then
+    add_result "Kernel" "PASS" "KRN-01" "Unprivileged user namespaces disabled" \
+      "Espaces de noms utilisateur non privilégiés désactivés" "unprivileged_userns_clone=0" ""
+    _krn_door closed
+  else
+    add_result "Kernel" "WARN" "KRN-01" "Unprivileged user namespaces allowed" \
+      "Espaces de noms utilisateur non privilégiés autorisés" "unprivileged_userns_clone=$_KRN_USERNS" \
+      "Porte d'entrée de nombreuses élévations de privilèges locales. 'sysctl -w kernel.unprivileged_userns_clone=0'. Casse Docker/Podman rootless et le bac à sable de Chrome."
+    _krn_door open
+  fi
+else
+  _KRN_USERNS="$(_krn_sysctl user.max_user_namespaces)"            # RHEL family
+  if [[ "$_KRN_USERNS" == "0" ]]; then
+    add_result "Kernel" "PASS" "KRN-01" "Unprivileged user namespaces disabled" \
+      "Espaces de noms utilisateur non privilégiés désactivés" "user.max_user_namespaces=0" ""
+    _krn_door closed
+  elif [[ "$_KRN_USERNS" == "?" ]]; then
+    add_result "Kernel" "WARN" "KRN-01" "Cannot determine user namespace policy" \
+      "Politique des espaces de noms indéterminée" "no unprivileged_userns_clone or max_user_namespaces" ""
+    _krn_door na
+  else
+    add_result "Kernel" "WARN" "KRN-01" "Unprivileged user namespaces allowed" \
+      "Espaces de noms utilisateur non privilégiés autorisés" "user.max_user_namespaces=$_KRN_USERNS" \
+      "Porte d'entrée de nombreuses élévations de privilèges locales. 'sysctl -w user.max_user_namespaces=0'. Casse les conteneurs rootless."
+    _krn_door open
+  fi
+fi
+
+# ── KRN-02  Unprivileged eBPF ────────────────────────────────────────────────
+_KRN_BPF="$(_krn_sysctl kernel.unprivileged_bpf_disabled)"
+case "$_KRN_BPF" in
+  1|2) add_result "Kernel" "PASS" "KRN-02" "Unprivileged eBPF disabled" \
+         "eBPF non privilégié désactivé" "unprivileged_bpf_disabled=$_KRN_BPF" ""
+       _krn_door closed ;;
+  "?") add_result "Kernel" "WARN" "KRN-02" "eBPF policy not readable" \
+         "Politique eBPF illisible" "kernel.unprivileged_bpf_disabled absent" ""
+       _krn_door na ;;
+  *)   add_result "Kernel" "WARN" "KRN-02" "Unprivileged eBPF allowed" \
+         "eBPF non privilégié autorisé" "unprivileged_bpf_disabled=$_KRN_BPF" \
+         "Le vérificateur eBPF est une surface d'exploitation récurrente. 'sysctl -w kernel.unprivileged_bpf_disabled=1'"
+       _krn_door open ;;
+esac
+
+# ── KRN-03  io_uring ─────────────────────────────────────────────────────────
+# Young, large and fast-moving: a disproportionate share of recent LPEs.
+_KRN_URING="$(_krn_sysctl kernel.io_uring_disabled)"
+if [[ "$_KRN_URING" == "?" ]]; then
+  add_result "Kernel" "PASS" "KRN-03" "io_uring control not present" \
+    "Contrôle io_uring absent" "kernel.io_uring_disabled unsupported on this kernel" ""
+  _krn_door na
+elif [[ "$_KRN_URING" == "2" ]]; then
+  add_result "Kernel" "PASS" "KRN-03" "io_uring disabled" "io_uring désactivé" "io_uring_disabled=2" ""
+  _krn_door closed
+else
+  add_result "Kernel" "WARN" "KRN-03" "io_uring available to unprivileged users" \
+    "io_uring accessible sans privilège" "io_uring_disabled=$_KRN_URING" \
+    "Sous-système jeune et très exposé. 'sysctl -w kernel.io_uring_disabled=2' (1 = réservé au groupe io_uring_group). Peut affecter certaines bases de données et proxys."
+  _krn_door open
+fi
+
+# ── KRN-04  userfaultfd ──────────────────────────────────────────────────────
+# Not itself a bug, but what turns a race into a reliable exploit.
+_KRN_UFFD="$(_krn_sysctl vm.unprivileged_userfaultfd)"
+if [[ "$_KRN_UFFD" == "0" ]]; then
+  add_result "Kernel" "PASS" "KRN-04" "Unprivileged userfaultfd disabled" \
+    "userfaultfd non privilégié désactivé" "vm.unprivileged_userfaultfd=0" ""
+  _krn_door closed
+elif [[ "$_KRN_UFFD" == "?" ]]; then
+  add_result "Kernel" "PASS" "KRN-04" "userfaultfd control not present" \
+    "Contrôle userfaultfd absent" "vm.unprivileged_userfaultfd unsupported" ""
+  _krn_door na
+else
+  add_result "Kernel" "WARN" "KRN-04" "Unprivileged userfaultfd allowed" \
+    "userfaultfd non privilégié autorisé" "vm.unprivileged_userfaultfd=$_KRN_UFFD" \
+    "Utilisé pour fiabiliser l'exploitation des conditions de course noyau. 'sysctl -w vm.unprivileged_userfaultfd=0'"
+  _krn_door open
+fi
+
+# ── KRN-05  Kernel module loading ────────────────────────────────────────────
+_KRN_MODLOCK="$(_krn_sysctl kernel.modules_disabled)"
+if [[ "$_KRN_MODLOCK" == "1" ]]; then
+  add_result "Kernel" "PASS" "KRN-05" "Module loading locked" "Chargement de modules verrouillé" "kernel.modules_disabled=1" ""
+else
+  add_result "Kernel" "WARN" "KRN-05" "Module loading open" "Chargement de modules ouvert" "kernel.modules_disabled=${_KRN_MODLOCK/\?/0}" \
+    "Verrouiller après le démarrage empêche le chargement d'un rootkit en module. 'sysctl -w kernel.modules_disabled=1' une fois la machine stabilisée. Irréversible jusqu'au redémarrage."
+fi
+
+# ── KRN-06  kexec ────────────────────────────────────────────────────────────
+_KRN_KEXEC="$(_krn_sysctl kernel.kexec_load_disabled)"
+if [[ "$_KRN_KEXEC" == "1" ]]; then
+  add_result "Kernel" "PASS" "KRN-06" "kexec disabled" "kexec désactivé" "kexec_load_disabled=1" ""
+else
+  add_result "Kernel" "WARN" "KRN-06" "kexec allowed" "kexec autorisé" "kexec_load_disabled=${_KRN_KEXEC/\?/0}" \
+    "kexec permet de démarrer un noyau arbitraire sans passer par le firmware, contournant Secure Boot. 'sysctl -w kernel.kexec_load_disabled=1'"
+fi
+
+# ── KRN-07  TTY line discipline autoload ─────────────────────────────────────
+_KRN_LDISC="$(_krn_sysctl dev.tty.ldisc_autoload)"
+if [[ "$_KRN_LDISC" == "0" ]]; then
+  add_result "Kernel" "PASS" "KRN-07" "TTY line discipline autoload disabled" \
+    "Chargement auto des disciplines TTY désactivé" "dev.tty.ldisc_autoload=0" ""
+elif [[ "$_KRN_LDISC" == "?" ]]; then
+  add_result "Kernel" "PASS" "KRN-07" "ldisc autoload control not present" \
+    "Contrôle ldisc absent" "dev.tty.ldisc_autoload unsupported" ""
+else
+  add_result "Kernel" "WARN" "KRN-07" "TTY line discipline autoload enabled" \
+    "Chargement auto des disciplines TTY activé" "dev.tty.ldisc_autoload=$_KRN_LDISC" \
+    "Permet à un utilisateur non privilégié de charger des modules TTY anciens et peu audités. 'sysctl -w dev.tty.ldisc_autoload=0'"
+fi
+
+# ── KRN-08  Kernel lockdown ──────────────────────────────────────────────────
+if [[ -r /sys/kernel/security/lockdown ]]; then
+  _KRN_LOCKDOWN="$(sed -n 's/.*\[\([a-z]*\)\].*/\1/p' /sys/kernel/security/lockdown 2>/dev/null)"
+  case "$_KRN_LOCKDOWN" in
+    integrity|confidentiality)
+      add_result "Kernel" "PASS" "KRN-08" "Kernel lockdown active" "Verrouillage noyau actif" "lockdown=$_KRN_LOCKDOWN" "" ;;
+    *)
+      add_result "Kernel" "WARN" "KRN-08" "Kernel lockdown off" "Verrouillage noyau inactif" "lockdown=${_KRN_LOCKDOWN:-none}" \
+        "Empêche même root de modifier le noyau en cours d'exécution. S'active via Secure Boot ou 'lockdown=integrity' sur la ligne de commande du noyau." ;;
+  esac
+else
+  add_result "Kernel" "WARN" "KRN-08" "Kernel lockdown not available" "Verrouillage noyau indisponible" \
+    "/sys/kernel/security/lockdown absent" "Nécessite un noyau compilé avec CONFIG_SECURITY_LOCKDOWN_LSM."
+fi
+
+# ── KRN-09  BPF JIT hardening ────────────────────────────────────────────────
+_KRN_JIT="$(_krn_sysctl net.core.bpf_jit_harden)"
+if [[ "$_KRN_JIT" =~ ^[12]$ ]]; then
+  add_result "Kernel" "PASS" "KRN-09" "BPF JIT hardening on" "Durcissement JIT BPF actif" "bpf_jit_harden=$_KRN_JIT" ""
+elif [[ "$_KRN_JIT" == "?" ]]; then
+  add_result "Kernel" "PASS" "KRN-09" "BPF JIT control not present" "Contrôle JIT BPF absent" "net.core.bpf_jit_harden unsupported" ""
+else
+  add_result "Kernel" "WARN" "KRN-09" "BPF JIT hardening off" "Durcissement JIT BPF inactif" "bpf_jit_harden=$_KRN_JIT" \
+    "Sans durcissement, le JIT facilite la pulvérisation de code en mémoire noyau. 'sysctl -w net.core.bpf_jit_harden=2'"
+fi
+
+# ── KRN-10  SysRq ────────────────────────────────────────────────────────────
+_KRN_SYSRQ="$(_krn_sysctl kernel.sysrq)"
+if [[ "$_KRN_SYSRQ" == "0" || "$_KRN_SYSRQ" == "4" ]]; then
+  add_result "Kernel" "PASS" "KRN-10" "SysRq restricted" "SysRq restreint" "kernel.sysrq=$_KRN_SYSRQ" ""
+else
+  add_result "Kernel" "WARN" "KRN-10" "SysRq permissive" "SysRq permissif" "kernel.sysrq=${_KRN_SYSRQ/\?/unknown}" \
+    "SysRq expose des opérations noyau depuis la console physique, dont un vidage mémoire. 'sysctl -w kernel.sysrq=0' (4 conserve seulement le rappel clavier)."
+fi
+
+# ── KRN-11  Exotic filesystem modules ────────────────────────────────────────
+# Rarely used, rarely audited, historically a steady source of CVEs. Reached by
+# anyone who can plug in a USB stick or mount an image.
+_KRN_FS_LOADED=""
+for _m in cramfs freevxfs jffs2 hfs hfsplus squashfs udf ksmbd; do
+  lsmod 2>/dev/null | awk '{print $1}' | grep -qx "$_m" && _KRN_FS_LOADED+="$_m "
+done
+if [[ -z "$_KRN_FS_LOADED" ]]; then
+  add_result "Kernel" "PASS" "KRN-11" "No exotic filesystem modules loaded" \
+    "Aucun module de système de fichiers exotique chargé" "cramfs/freevxfs/jffs2/hfs/hfsplus/udf/ksmbd absent" ""
+else
+  add_result "Kernel" "WARN" "KRN-11" "Exotic filesystem modules loaded" \
+    "Modules de systèmes de fichiers exotiques chargés" "loaded: ${_KRN_FS_LOADED% }" \
+    "Peu utilisés, peu audités, source régulière de CVE. Ajoutez 'install <module> /bin/true' dans /etc/modprobe.d/ pour ceux dont vous n'avez pas besoin."
+fi
+
+# ── KRN-12  Exposure summary ─────────────────────────────────────────────────
+# The point of the family, stated once: how many doorways are still open.
+# Counts the verdicts recorded above; it does not re-read a single sysctl.
+if [[ "$_KRN_DOORS_KNOWN" -eq 0 ]]; then
+  add_result "Kernel" "WARN" "KRN-12" "LPE doorway status unknown" \
+    "État des portes d'élévation inconnu" "no doorway control readable on this kernel" ""
+elif [[ "$_KRN_DOORS_OPEN" -eq 0 ]]; then
+  add_result "Kernel" "PASS" "KRN-12" "Primary LPE doorways closed" \
+    "Principales portes d'élévation fermées" "$_KRN_DOORS_KNOWN of $_KRN_DOORS_KNOWN closed" ""
+else
+  add_result "Kernel" "WARN" "KRN-12" "Primary LPE doorways open" \
+    "Principales portes d'élévation ouvertes" \
+    "$_KRN_DOORS_OPEN of $_KRN_DOORS_KNOWN open (userns, eBPF, io_uring, userfaultfd)" \
+    "Ces réglages neutralisent des classes entières d'exploits, sans correctif et sans redémarrage. Voir 'aartool surface'."
+fi

--- a/scripts/tests/test_aartool.sh
+++ b/scripts/tests/test_aartool.sh
@@ -81,10 +81,43 @@ check    "missing inventory points at the example" \
          "$(AARTOOL_INVENTORY=/nonexistent/hosts $AARTOOL plan -t any 2>&1)" \
          "cp "
 
+# ── surface and doctor ───────────────────────────────────────────────────────
+check    "surface runs read-only"  "$($AARTOOL surface 2>&1)"          "Kernel attack surface"
+check    "surface names the tier"  "$($AARTOOL surface 2>&1)"          "safe tier only"
+check    "surface --strict widens" "$($AARTOOL surface --strict 2>&1)" "KRN-01"
+check    "surface --fix emits a drop-in" "$($AARTOOL surface --fix 2>&1)" "sysctl --system"
+check_rc "surface changes nothing without --apply" 0 "$AARTOOL" surface
+check    "doctor reports"          "$($AARTOOL doctor 2>&1)"           "toolkit located"
+
+# --apply must not be satisfiable by a pipe, same rule as 'apply'.
+check    "surface --apply needs root or a tty" \
+         "$($AARTOOL surface --apply </dev/null 2>&1)" \
+         "root"
+
+# ── The catalogue and the audit must not drift ───────────────────────────────
+# Every doorway aartool offers to close has a KRN check that reports on it, and
+# every KRN check that maps to a sysctl is offered. Without this, someone adds a
+# mitigation to one side and the two views of the same machine start disagreeing
+# — which is exactly the class of bug this toolkit exists to find.
+cat_ids=$(bash -c 'source aartool-src/lib/surface.sh; surface_catalogue' | cut -f1 | sort -u)
+krn_ids=$(grep -ohE '"KRN-[0-9]{2}"' src/checks/kernel.sh | tr -d '"' | sort -u)
+missing=""
+for id in $cat_ids; do
+  printf '%s\n' "$krn_ids" | grep -qx "$id" || missing="$missing $id"
+done
+if [[ -z "$missing" ]]; then
+  PASS=$((PASS + 1))
+else
+  FAIL=$((FAIL + 1))
+  printf 'FAIL  catalogue entries with no KRN check:%s\n' "$missing"
+fi
+
 # ── Per-command help ─────────────────────────────────────────────────────────
 check    "inspect help" "$($AARTOOL inspect --help 2>&1)" "Changes nothing"
 check    "plan help"    "$($AARTOOL plan --help 2>&1)"    "--target"
 check    "apply help"   "$($AARTOOL apply --help 2>&1)"   "--yes"
+check    "surface help" "$($AARTOOL surface --help 2>&1)" "--strict"
+check    "doctor help"  "$($AARTOOL doctor --help 2>&1)"  "Changes nothing"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Red Hat and Debian ship the patch. **Nothing helps with the window before the patch exists**, or with the machine that cannot be rebooted until the change window in three weeks. That window is what this adds.

## KRN-01..KRN-12, a new check family

Every other family asks "is this configured correctly". This one asks **"when the next local privilege escalation lands, does it reach you"**.

These close **classes** of exploit rather than individual CVEs. Unprivileged user namespaces are the clearest case: they hand an unprivileged process `CAP_SYS_ADMIN` inside its own namespace, which is what turns a bug in nftables, io_uring or OverlayFS into root. Disabling them fixes none of those bugs and neutralises all of them.

Covered: user namespaces, unprivileged eBPF, io_uring, userfaultfd, module loading, kexec, TTY line-discipline autoload, kernel lockdown, BPF JIT hardening, SysRq, exotic filesystem modules, and a doorway summary. **96 checks become 109.**

They are WARN and never FAIL, deliberately. Several break real workloads. A tool that fails a build over a setting the workload requires teaches people to ignore it.

## `aartool surface`

```
aartool surface              assess, changes nothing
aartool surface --strict     include mitigations that cost something
aartool surface --fix        print the sysctl drop-in
sudo aartool surface --apply write it to /etc/sysctl.d and load it
```

**Two tiers, because the honest constraint here is not technical.** `safe` means no mainstream workload is known to depend on it. `strict` means it will break something real, and the cost is printed beside it — user namespaces reads *"breaks rootless Docker and Podman, Chrome's sandbox, and most CI runners"*. Only safe runs by default.

Applied as a drop-in rather than `sysctl -w`, so it survives a reboot and reverts by deleting one file.

## `aartool doctor`

Everything `plan` and `apply` depend on, reported at once, exiting non-zero so it works as a CI gate. It names the two collections separately, because "install the collections" is not actionable when one is already there.

## Two bugs of my own, both caught by running it

**KRN-12 disagreed with itself.** It summarised the doorways by re-reading the sysctls instead of counting the verdicts above it, so KRN-02 passed on `unprivileged_bpf_disabled=2` while the summary, matching only `1`, counted the same setting as open. It now counts recorded verdicts.

**`((n++))` returns exit status 1 when n is 0**, so under `set -e` the first increment killed the command.

A test asserts every catalogue entry has a matching KRN check, so remediation and audit cannot drift. **I verified that test fails when drift is introduced** rather than assuming it works. 30 tests, shellcheck clean.