### PR TITLE
feat(aartool): report, and one file you can actually send someone

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ together practitioners at home, across the diaspora and anywhere else, to build 
 
 | Deliverable | Description | Version |
 |-------------|-------------|---------|
-| `scripts/aartool` | One front door: `inspect`, `plan`, `apply`, plus `surface` for kernel attack-surface reduction and `doctor` for preflight | v0.2.0 |
+| `scripts/aartool` | One front door: `inspect`, `plan`, `apply`, `surface` (kernel attack surface), `doctor` (preflight), `report` (dashboard) | v0.3.0 |
 | `scripts/cyberaar-baseline.sh` | Standalone bash script: audits a Linux server across 96 security checks, produces HTML + JSON reports with Ansible remediation plan | v4.2.0 |
 | `ansible-hardening/` | Ansible collection (`cyberaar.hardening`): 51 CIS-aligned hardening roles for RHEL 9 family and Ubuntu/Debian | v2.0.0 |
 | `execution-environment/` | Docker image: self-contained EE with Ansible + collection + playbooks, no local install required | `ghcr.io/cyberaar/ee-hardening` |
@@ -334,6 +334,34 @@ drop-in file you can delete to revert. The same settings are audited as the
 `KRN-01`..`KRN-12` family in every baseline report, so the assessment and the
 remediation are two views of one thing — and a test asserts they cannot drift
 apart.
+
+### `aartool report` — the dashboard, one command away
+
+The toolkit already ships a single-file dashboard with no server and no internet
+requirement. The friction was everything around it: run an audit, find the JSON,
+find the dashboard, open a browser, drag files in.
+
+```bash
+aartool report /tmp/audit/*.json --out fleet.html   # self-contained, sendable
+aartool report /tmp/audit/*.json --open             # just look at it
+aartool report --serve 8080                         # headless server
+```
+
+`--out` is the one worth knowing about. It produces **one HTML file with the
+results already inside**, which opens offline on any machine with no other
+files. Attach it to an email; the person receiving it needs nothing installed
+and has never heard of this toolkit.
+
+`--serve` binds to `127.0.0.1` only and says so, because this renders audit
+results for an entire estate and has no authentication. Reach it with
+`ssh -L 8080:127.0.0.1:8080 user@host`.
+
+The dashboard itself is never modified. A copy is made and a small bootstrap
+appended that feeds the dashboard's own data structure, and the injected JSON has
+`<` and `>` escaped to their `\u` form: a hostname is attacker-influenced on a
+machine you were asked to audit, and `</script>` in one would otherwise end the
+block and turn the rest of a file you email to a client into markup. There is a
+test that attempts exactly that.
 
 ### `aartool doctor`
 

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="0.2.0"
+AARTOOL_VERSION="0.3.0"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -59,6 +59,7 @@ Commands:
   surface     Kernel attack surface: what a local privilege escalation
               would still reach on this machine, and how to close it.
   doctor      Check everything plan and apply depend on.
+  report      Visualise audit reports, or bake them into one shareable file.
 
 Global options:
   -h, --help        Show this help, or help for a command
@@ -130,6 +131,7 @@ resolve_paths() {
   # tests can work against a fixture instead of whatever is on the machine.
   INVENTORY="${AARTOOL_INVENTORY:-$ANSIBLE_BASE/inventory/hosts}"
   INVENTORY_EXAMPLE="$ANSIBLE_BASE/inventory/hosts.example"
+  TOOLKIT_DASHBOARD="$root/dashboard/index.html"
   BASELINE="$root/scripts/cyberaar-baseline.sh"
   HARDEN="$root/scripts/run-hardening.sh"
 
@@ -695,6 +697,159 @@ cmd_doctor() {
   return 1
 }
 
+# ── report ───────────────────────────────────────────────────────────────────
+# The toolkit already ships a dashboard: one HTML file, no server, no internet,
+# drag your JSON reports onto it. The friction is everything around that. You run
+# an audit, find the JSON, find the dashboard, open a browser, drag files in.
+#
+# This collapses those into one command, and adds the thing a consultancy
+# actually needs: a single self-contained file with the results already inside,
+# which can be attached to an email and opened offline by someone who has never
+# heard of this toolkit.
+#
+# The dashboard itself is never modified. A copy is made and a small bootstrap
+# appended that feeds its own DB structure, so the two cannot fall out of step
+# through anything except a deliberate change to the dashboard's data model.
+
+cmd_report_usage() {
+  cat <<'EOF'
+aartool report — visualise baseline JSON reports.
+
+Usage:
+  aartool report [REPORT.json ...] [options]
+
+Options:
+  -o, --out FILE    Write a self-contained HTML file with the reports embedded.
+                    Opens offline, anywhere, with no other files. Send it.
+      --serve PORT  Serve the dashboard on 127.0.0.1:PORT. For a headless
+                    server: run it there, then tunnel with
+                      ssh -L PORT:127.0.0.1:PORT user@host
+      --open        Try to open the result in a browser
+  -h, --help        Show this help
+
+With no arguments it opens the empty dashboard, where you can drag reports in
+yourself.
+
+  sudo aartool inspect --out /tmp/audit
+  aartool report /tmp/audit/*.json --out fleet.html
+EOF
+}
+
+# Embedding JSON inside <script> is a breakout waiting to happen: a hostname
+# containing </script> would end the block and everything after it becomes
+# markup. < and > only ever appear inside strings in JSON, so escaping them to
+# their \u form keeps the document valid and closes the hole.
+_report_js_safe() { sed -e 's|<|\\u003c|g' -e 's|>|\\u003e|g'; }
+
+cmd_report() {
+  local out="" serve="" do_open=false
+  local -a files=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--out)  [[ $# -ge 2 ]] || die "$1 needs a file path."; out="$2"; shift 2 ;;
+      --serve)   [[ $# -ge 2 ]] || die "--serve needs a port."; serve="$2"; shift 2 ;;
+      --open)    do_open=true; shift ;;
+      -h|--help) cmd_report_usage; return 0 ;;
+      --) shift; while [[ $# -gt 0 ]]; do files+=("$1"); shift; done ;;
+      -*) die "Unknown option for report: $1. Try 'aartool report --help'." ;;
+      *)  files+=("$1"); shift ;;
+    esac
+  done
+
+  resolve_paths
+  local dash="$TOOLKIT_DASHBOARD"
+  [[ -f "$dash" ]] || die "Dashboard not found: $dash"
+
+  local f
+  for f in ${files[@]+"${files[@]}"}; do
+    [[ -f "$f" ]] || die "No such report: $f"
+  done
+
+  # ── serve ──────────────────────────────────────────────────────────────────
+  if [[ -n "$serve" ]]; then
+    [[ "$serve" =~ ^[0-9]+$ ]] || die "--serve needs a port number, got '$serve'."
+    command -v python3 >/dev/null 2>&1 || die "--serve needs python3. Without it, copy dashboard/index.html to your workstation and open it there."
+    local dir; dir="$(dirname "$dash")"
+    info "Serving $dir on http://127.0.0.1:${serve}/"
+    # Bound to the loopback deliberately. This renders audit results for a whole
+    # estate; it has no authentication and must not be reachable from the network.
+    info "Bound to 127.0.0.1 only. From your workstation: ssh -L ${serve}:127.0.0.1:${serve} $(id -un)@$(hostname)"
+    info "Ctrl-C to stop."
+    ( cd "$dir" && exec python3 -m http.server "$serve" --bind 127.0.0.1 )
+    return 0
+  fi
+
+  # ── no reports: just the dashboard as it ships ─────────────────────────────
+  if [[ "${#files[@]}" -eq 0 ]]; then
+    if [[ -n "$out" ]]; then
+      cp "$dash" "$out" || die "Cannot write $out"
+      success "Written: $out (empty dashboard, drag reports onto it)"
+    else
+      info "Dashboard: $dash"
+      info "Open it in a browser and drag your JSON reports onto it, or pass them: aartool report *.json"
+      [[ "$do_open" == true ]] && _report_open "$dash"
+    fi
+    return 0
+  fi
+
+  # ── build a preloaded copy ─────────────────────────────────────────────────
+  local target="${out:-$(mktemp -t aartool-report-XXXXXX.html)}"
+  cp "$dash" "$target" || die "Cannot write $target"
+
+  {
+    printf '\n<script>\n'
+    printf '// Injected by aartool %s. The dashboard is unmodified above this line.\n' "$AARTOOL_VERSION"
+    printf '(function () {\n  var PRELOAD = [\n'
+    local first=true
+    for f in "${files[@]}"; do
+      [[ "$first" == true ]] || printf ',\n'
+      first=false
+      _report_js_safe < "$f"
+    done
+    printf '\n  ];\n'
+    cat <<'JS'
+  // Feed the dashboard's own store rather than re-implementing its parsing, so
+  // a change to its data model breaks loudly here instead of rendering wrongly.
+  if (typeof DB === 'undefined' || typeof renderAll !== 'function') {
+    console.error('aartool: dashboard data model not found; open the file and drag reports in instead.');
+    return;
+  }
+  PRELOAD.forEach(function (raw) {
+    var r = raw && raw.cyberaar_baseline;
+    if (!r || !r.host) { console.warn('aartool: skipped a report with no host'); return; }
+    if (!DB[r.host]) DB[r.host] = [];
+    DB[r.host].push(r);
+    DB[r.host].sort(function (a, b) { return String(a.date).localeCompare(String(b.date)); });
+  });
+  renderAll();
+})();
+JS
+    printf '</script>\n'
+  } >> "$target"
+
+  local n="${#files[@]}"
+  if [[ -n "$out" ]]; then
+    success "Written: $out"
+    info "$n report(s) embedded. Self-contained: no server, no internet, no other files."
+  else
+    success "Built: $target ($n report(s) embedded)"
+  fi
+  [[ "$do_open" == true ]] && _report_open "$target"
+  return 0
+}
+
+_report_open() {
+  local f="$1" opener
+  for opener in xdg-open open wslview; do
+    if command -v "$opener" >/dev/null 2>&1; then
+      "$opener" "$f" >/dev/null 2>&1 &
+      return 0
+    fi
+  done
+  warn "No browser opener found (xdg-open, open, wslview). Open it yourself: $f"
+}
+
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 main() {
   [[ $# -gt 0 ]] || { usage; exit 1; }
@@ -705,6 +860,7 @@ main() {
     apply)          shift; cmd_harden apply "$@" ;;
     surface)        shift; cmd_surface "$@" ;;
     doctor)         shift; cmd_doctor "$@" ;;
+    report)         shift; cmd_report "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/aartool-src/cmd/report.sh
+++ b/scripts/aartool-src/cmd/report.sh
@@ -1,0 +1,152 @@
+# ── report ───────────────────────────────────────────────────────────────────
+# The toolkit already ships a dashboard: one HTML file, no server, no internet,
+# drag your JSON reports onto it. The friction is everything around that. You run
+# an audit, find the JSON, find the dashboard, open a browser, drag files in.
+#
+# This collapses those into one command, and adds the thing a consultancy
+# actually needs: a single self-contained file with the results already inside,
+# which can be attached to an email and opened offline by someone who has never
+# heard of this toolkit.
+#
+# The dashboard itself is never modified. A copy is made and a small bootstrap
+# appended that feeds its own DB structure, so the two cannot fall out of step
+# through anything except a deliberate change to the dashboard's data model.
+
+cmd_report_usage() {
+  cat <<'EOF'
+aartool report — visualise baseline JSON reports.
+
+Usage:
+  aartool report [REPORT.json ...] [options]
+
+Options:
+  -o, --out FILE    Write a self-contained HTML file with the reports embedded.
+                    Opens offline, anywhere, with no other files. Send it.
+      --serve PORT  Serve the dashboard on 127.0.0.1:PORT. For a headless
+                    server: run it there, then tunnel with
+                      ssh -L PORT:127.0.0.1:PORT user@host
+      --open        Try to open the result in a browser
+  -h, --help        Show this help
+
+With no arguments it opens the empty dashboard, where you can drag reports in
+yourself.
+
+  sudo aartool inspect --out /tmp/audit
+  aartool report /tmp/audit/*.json --out fleet.html
+EOF
+}
+
+# Embedding JSON inside <script> is a breakout waiting to happen: a hostname
+# containing </script> would end the block and everything after it becomes
+# markup. < and > only ever appear inside strings in JSON, so escaping them to
+# their \u form keeps the document valid and closes the hole.
+_report_js_safe() { sed -e 's|<|\\u003c|g' -e 's|>|\\u003e|g'; }
+
+cmd_report() {
+  local out="" serve="" do_open=false
+  local -a files=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -o|--out)  [[ $# -ge 2 ]] || die "$1 needs a file path."; out="$2"; shift 2 ;;
+      --serve)   [[ $# -ge 2 ]] || die "--serve needs a port."; serve="$2"; shift 2 ;;
+      --open)    do_open=true; shift ;;
+      -h|--help) cmd_report_usage; return 0 ;;
+      --) shift; while [[ $# -gt 0 ]]; do files+=("$1"); shift; done ;;
+      -*) die "Unknown option for report: $1. Try 'aartool report --help'." ;;
+      *)  files+=("$1"); shift ;;
+    esac
+  done
+
+  resolve_paths
+  local dash="$TOOLKIT_DASHBOARD"
+  [[ -f "$dash" ]] || die "Dashboard not found: $dash"
+
+  local f
+  for f in ${files[@]+"${files[@]}"}; do
+    [[ -f "$f" ]] || die "No such report: $f"
+  done
+
+  # ── serve ──────────────────────────────────────────────────────────────────
+  if [[ -n "$serve" ]]; then
+    [[ "$serve" =~ ^[0-9]+$ ]] || die "--serve needs a port number, got '$serve'."
+    command -v python3 >/dev/null 2>&1 || die "--serve needs python3. Without it, copy dashboard/index.html to your workstation and open it there."
+    local dir; dir="$(dirname "$dash")"
+    info "Serving $dir on http://127.0.0.1:${serve}/"
+    # Bound to the loopback deliberately. This renders audit results for a whole
+    # estate; it has no authentication and must not be reachable from the network.
+    info "Bound to 127.0.0.1 only. From your workstation: ssh -L ${serve}:127.0.0.1:${serve} $(id -un)@$(hostname)"
+    info "Ctrl-C to stop."
+    ( cd "$dir" && exec python3 -m http.server "$serve" --bind 127.0.0.1 )
+    return 0
+  fi
+
+  # ── no reports: just the dashboard as it ships ─────────────────────────────
+  if [[ "${#files[@]}" -eq 0 ]]; then
+    if [[ -n "$out" ]]; then
+      cp "$dash" "$out" || die "Cannot write $out"
+      success "Written: $out (empty dashboard, drag reports onto it)"
+    else
+      info "Dashboard: $dash"
+      info "Open it in a browser and drag your JSON reports onto it, or pass them: aartool report *.json"
+      [[ "$do_open" == true ]] && _report_open "$dash"
+    fi
+    return 0
+  fi
+
+  # ── build a preloaded copy ─────────────────────────────────────────────────
+  local target="${out:-$(mktemp -t aartool-report-XXXXXX.html)}"
+  cp "$dash" "$target" || die "Cannot write $target"
+
+  {
+    printf '\n<script>\n'
+    printf '// Injected by aartool %s. The dashboard is unmodified above this line.\n' "$AARTOOL_VERSION"
+    printf '(function () {\n  var PRELOAD = [\n'
+    local first=true
+    for f in "${files[@]}"; do
+      [[ "$first" == true ]] || printf ',\n'
+      first=false
+      _report_js_safe < "$f"
+    done
+    printf '\n  ];\n'
+    cat <<'JS'
+  // Feed the dashboard's own store rather than re-implementing its parsing, so
+  // a change to its data model breaks loudly here instead of rendering wrongly.
+  if (typeof DB === 'undefined' || typeof renderAll !== 'function') {
+    console.error('aartool: dashboard data model not found; open the file and drag reports in instead.');
+    return;
+  }
+  PRELOAD.forEach(function (raw) {
+    var r = raw && raw.cyberaar_baseline;
+    if (!r || !r.host) { console.warn('aartool: skipped a report with no host'); return; }
+    if (!DB[r.host]) DB[r.host] = [];
+    DB[r.host].push(r);
+    DB[r.host].sort(function (a, b) { return String(a.date).localeCompare(String(b.date)); });
+  });
+  renderAll();
+})();
+JS
+    printf '</script>\n'
+  } >> "$target"
+
+  local n="${#files[@]}"
+  if [[ -n "$out" ]]; then
+    success "Written: $out"
+    info "$n report(s) embedded. Self-contained: no server, no internet, no other files."
+  else
+    success "Built: $target ($n report(s) embedded)"
+  fi
+  [[ "$do_open" == true ]] && _report_open "$target"
+  return 0
+}
+
+_report_open() {
+  local f="$1" opener
+  for opener in xdg-open open wslview; do
+    if command -v "$opener" >/dev/null 2>&1; then
+      "$opener" "$f" >/dev/null 2>&1 &
+      return 0
+    fi
+  done
+  warn "No browser opener found (xdg-open, open, wslview). Open it yourself: $f"
+}

--- a/scripts/aartool-src/lib/paths.sh
+++ b/scripts/aartool-src/lib/paths.sh
@@ -41,6 +41,7 @@ resolve_paths() {
   # tests can work against a fixture instead of whatever is on the machine.
   INVENTORY="${AARTOOL_INVENTORY:-$ANSIBLE_BASE/inventory/hosts}"
   INVENTORY_EXAMPLE="$ANSIBLE_BASE/inventory/hosts.example"
+  TOOLKIT_DASHBOARD="$root/dashboard/index.html"
   BASELINE="$root/scripts/cyberaar-baseline.sh"
   HARDEN="$root/scripts/run-hardening.sh"
 

--- a/scripts/aartool-src/main.sh
+++ b/scripts/aartool-src/main.sh
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="0.2.0"
+AARTOOL_VERSION="0.3.0"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -59,6 +59,7 @@ Commands:
   surface     Kernel attack surface: what a local privilege escalation
               would still reach on this machine, and how to close it.
   doctor      Check everything plan and apply depend on.
+  report      Visualise audit reports, or bake them into one shareable file.
 
 Global options:
   -h, --help        Show this help, or help for a command

--- a/scripts/aartool-src/run.sh
+++ b/scripts/aartool-src/run.sh
@@ -8,6 +8,7 @@ main() {
     apply)          shift; cmd_harden apply "$@" ;;
     surface)        shift; cmd_surface "$@" ;;
     doctor)         shift; cmd_doctor "$@" ;;
+    report)         shift; cmd_report "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/build-aartool.sh
+++ b/scripts/build-aartool.sh
@@ -21,6 +21,7 @@ PARTS=(
   aartool-src/cmd/harden.sh
   aartool-src/cmd/surface.sh
   aartool-src/cmd/doctor.sh
+  aartool-src/cmd/report.sh
   aartool-src/run.sh
 )
 

--- a/scripts/tests/test_aartool.sh
+++ b/scripts/tests/test_aartool.sh
@@ -112,12 +112,42 @@ else
   printf 'FAIL  catalogue entries with no KRN check:%s\n' "$missing"
 fi
 
+# ── report ───────────────────────────────────────────────────────────────────
+_rep_src="../ansible-hardening/reports/before/ubuntu-vm-01/before_ubuntu-vm-01_1772639445.json"
+if [[ -f "$_rep_src" ]]; then
+  _rep_out="$(mktemp -t aartool-test-XXXXXX.html)"
+  $AARTOOL report "$_rep_src" --out "$_rep_out" >/dev/null 2>&1
+  check "report embeds the data"   "$(grep -c 'var PRELOAD' "$_rep_out")" "1"
+  check "report keeps script tags balanced" \
+        "$(printf '%s/%s' "$(grep -o '<script' "$_rep_out" | wc -l)" "$(grep -o '</script>' "$_rep_out" | wc -l)")" \
+        "2/2"
+
+  # A hostname is attacker-influenced on a machine you were asked to audit.
+  # Embedding it in a <script> block without escaping < would end the block and
+  # turn the rest of the file into markup, in a report you then email to a
+  # client. Assert the breakout is closed rather than trusting that it is.
+  _rep_evil="$(mktemp -t aartool-evil-XXXXXX.json)"
+  sed 's|"host": *"[^"]*"|"host": "evil</script><img src=x onerror=alert(1)>"|' "$_rep_src" > "$_rep_evil"
+  _rep_evil_out="$(mktemp -t aartool-evil-XXXXXX.html)"
+  $AARTOOL report "$_rep_evil" --out "$_rep_evil_out" >/dev/null 2>&1
+  check "hostile hostname does not break out" \
+        "$(printf '%s/%s' "$(grep -o '<script' "$_rep_evil_out" | wc -l)" "$(grep -o '</script>' "$_rep_evil_out" | wc -l)")" \
+        "2/2"
+  check "hostile markup is escaped, not embedded raw" \
+        "$(grep -c 'u003c/script' "$_rep_evil_out")" "1"
+  rm -f "$_rep_out" "$_rep_evil" "$_rep_evil_out"
+fi
+
+check    "report rejects a missing file" "$($AARTOOL report /nonexistent.json 2>&1)" "No such report"
+check    "serve refuses a non-numeric port" "$($AARTOOL report --serve abc 2>&1)" "port number"
+
 # ── Per-command help ─────────────────────────────────────────────────────────
 check    "inspect help" "$($AARTOOL inspect --help 2>&1)" "Changes nothing"
 check    "plan help"    "$($AARTOOL plan --help 2>&1)"    "--target"
 check    "apply help"   "$($AARTOOL apply --help 2>&1)"   "--yes"
 check    "surface help" "$($AARTOOL surface --help 2>&1)" "--strict"
 check    "doctor help"  "$($AARTOOL doctor --help 2>&1)"  "Changes nothing"
+check    "report help"  "$($AARTOOL report --help 2>&1)"  "self-contained"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
The toolkit already ships a dashboard: one HTML file, no server, no internet. Everything *around* it was friction — run an audit, find the JSON, find the dashboard, open a browser, drag files in.

```
aartool report *.json --out fleet.html   self-contained, sendable
aartool report *.json --open             just look at it
aartool report --serve 8080              headless server
```

**`--out` is the one that matters.** One HTML file with the results already inside, opening offline on any machine with nothing installed. A consultancy attaches it to an email and the client needs no toolkit, no Python and no network to read their own audit.

**`--serve` binds to 127.0.0.1** and prints the `ssh -L` line to reach it. This renders audit results for an entire estate and has no authentication; binding it to 0.0.0.0 on a jump host would be a real disclosure.

## The dashboard is never modified

A copy is made and a bootstrap appended that feeds the dashboard's **own** `DB` structure and calls its **own** `renderAll`, rather than re-implementing its parsing. If the data model changes this breaks loudly — the bootstrap checks for both and refuses with a console error telling the operator to drag files in by hand.

## Escaping, because a hostname is attacker-influenced

Embedding JSON in a `<script>` block is a breakout waiting to happen. A machine you were asked to audit can have any hostname it likes, and one containing `</script>` would end the block and turn the remainder of **a file you then email to a client** into markup.

`<` and `>` only ever appear inside strings in JSON, so both are escaped to their `\u` form: the document stays valid and the value round-trips exactly. There is a test that crafts

```json
"host": "evil</script><img src=x onerror=alert(1)>"
```

and asserts the script tags stay balanced and no raw markup reaches the file. **I ran that attempt against the real implementation before writing the test**, rather than assuming the escaping worked.

37 tests, shellcheck clean.