### PR TITLE
feat(aartool): diff, for the machine nobody is watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ together practitioners at home, across the diaspora and anywhere else, to build 
 
 | Deliverable | Description | Version |
 |-------------|-------------|---------|
-| `scripts/aartool` | One front door: `inspect`, `plan`, `apply`, `surface` (kernel attack surface), `doctor` (preflight), `report` (dashboard) | v0.3.0 |
+| `scripts/aartool` | One front door: `inspect`, `plan`, `apply`, `surface` (kernel attack surface), `doctor` (preflight), `report` (dashboard), `diff` (drift) | v0.4.0 |
 | `scripts/cyberaar-baseline.sh` | Standalone bash script: audits a Linux server across 96 security checks, produces HTML + JSON reports with Ansible remediation plan | v4.2.0 |
 | `ansible-hardening/` | Ansible collection (`cyberaar.hardening`): 51 CIS-aligned hardening roles for RHEL 9 family and Ubuntu/Debian | v2.0.0 |
 | `execution-environment/` | Docker image: self-contained EE with Ansible + collection + playbooks, no local install required | `ghcr.io/cyberaar/ee-hardening` |
@@ -362,6 +362,31 @@ appended that feeds the dashboard's own data structure, and the injected JSON ha
 machine you were asked to audit, and `</script>` in one would otherwise end the
 block and turn the rest of a file you email to a client into markup. There is a
 test that attempts exactly that.
+
+### `aartool diff` — drift, and the exit code that makes it useful
+
+```bash
+aartool diff last-week.json today.json
+aartool diff last.json today.json --quiet || mail -s "drift on $(hostname)" soc@example.com
+```
+
+| exit | meaning |
+|---|---|
+| `0` | nothing regressed |
+| `1` | at least one check regressed |
+| `2` | the reports could not be compared |
+
+The exit code is the whole feature. A weekly audit that mails you 109 results
+teaches you to filter the mail. One that stays silent unless something
+**regressed** is a thing you actually read, and `--quiet` prints nothing at all
+when nothing has changed.
+
+Regressions and improvements are deliberately not symmetric. PASS to FAIL is an
+alert; FAIL to PASS is a note at the bottom. Treating them the same is how a
+report becomes wallpaper.
+
+It refuses to compare two different hosts. A diff between two machines looks
+exactly like drift and is not.
 
 ### `aartool doctor`
 

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="0.3.0"
+AARTOOL_VERSION="0.4.0"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -60,6 +60,7 @@ Commands:
               would still reach on this machine, and how to close it.
   doctor      Check everything plan and apply depend on.
   report      Visualise audit reports, or bake them into one shareable file.
+  diff        What changed between two audits. Exits non-zero on a regression.
 
 Global options:
   -h, --help        Show this help, or help for a command
@@ -850,6 +851,173 @@ _report_open() {
   warn "No browser opener found (xdg-open, open, wslview). Open it yourself: $f"
 }
 
+# ── diff ─────────────────────────────────────────────────────────────────────
+# What changed between two audits of the same machine.
+#
+# This is the command that belongs in cron, and the reason is the exit code. A
+# weekly audit that mails you 109 results teaches you to filter the mail. One
+# that stays silent unless something REGRESSED is a thing you actually read.
+#
+#   aartool diff last-week.json today.json || mail -s "drift on $(hostname)" soc@
+#
+# Regressions and improvements are not symmetric here. A check going PASS to FAIL
+# is an alert; going FAIL to PASS is a note. Treating them the same is how a
+# report becomes wallpaper.
+
+cmd_diff_usage() {
+  cat <<'EOF'
+aartool diff — what changed between two audits. Changes nothing.
+
+Usage:
+  aartool diff BEFORE.json AFTER.json [options]
+
+Options:
+      --quiet     Print only regressions. Nothing at all when there are none,
+                  which is what you want in cron.
+  -h, --help      Show this help
+
+Exit codes:
+  0   nothing regressed
+  1   at least one check regressed
+  2   the reports could not be compared
+
+Built for cron:
+
+  aartool diff /var/log/cyberaar/last.json /var/log/cyberaar/today.json --quiet \
+    || mail -s "config drift on $(hostname)" soc@example.com
+EOF
+}
+
+cmd_diff() {
+  local quiet=false
+  local -a pos=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --quiet)   quiet=true; shift ;;
+      -h|--help) cmd_diff_usage; return 0 ;;
+      --) shift; while [[ $# -gt 0 ]]; do pos+=("$1"); shift; done ;;
+      -*) die "Unknown option for diff: $1. Try 'aartool diff --help'." ;;
+      *)  pos+=("$1"); shift ;;
+    esac
+  done
+
+  [[ "${#pos[@]}" -eq 2 ]] || die "diff needs exactly two reports: aartool diff BEFORE.json AFTER.json"
+  local before="${pos[0]}" after="${pos[1]}"
+  [[ -f "$before" ]] || die "No such report: $before"
+  [[ -f "$after"  ]] || die "No such report: $after"
+
+  command -v python3 >/dev/null 2>&1 \
+    || die "diff needs python3 to parse the reports. It is present on any machine that can run Ansible."
+
+  # Kept in python rather than jq: jq is not installed by default on RHEL,
+  # Ubuntu server or Alpine, and requiring it would put a package install between
+  # an operator and their own audit results.
+  python3 - "$before" "$after" "$quiet" <<'PY'
+import json, sys
+
+before_path, after_path, quiet = sys.argv[1], sys.argv[2], sys.argv[3] == "true"
+
+def load(p):
+    try:
+        with open(p, encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"[ERROR] Cannot read {p}: {e}\n"); sys.exit(2)
+    b = doc.get("cyberaar_baseline")
+    if not b:
+        sys.stderr.write(f"[ERROR] {p} is not a cyberaar-baseline report.\n"); sys.exit(2)
+    return b
+
+a, b = load(before_path), load(after_path)
+
+# Comparing two different machines silently would produce a diff that looks
+# real and means nothing.
+if a.get("host") and b.get("host") and a["host"] != b["host"]:
+    sys.stderr.write(
+        f"[ERROR] These are different hosts: '{a['host']}' and '{b['host']}'.\n"
+        f"        Comparing them would produce a difference that is not drift.\n")
+    sys.exit(2)
+
+RANK = {"PASS": 0, "WARN": 1, "FAIL": 2}
+def index(rep):
+    return {r["id"]: r for r in rep.get("results", []) if isinstance(r, dict) and "id" in r}
+
+ai, bi = index(a), index(b)
+
+regressed, improved, appeared, vanished = [], [], [], []
+for cid, br in bi.items():
+    ar = ai.get(cid)
+    if ar is None:
+        # A new check counts as drift only if it is already failing; a new
+        # passing check is just this tool having learned something.
+        if RANK.get(br.get("status"), 1) > 0:
+            appeared.append((cid, br))
+        continue
+    was, now = ar.get("status"), br.get("status")
+    if RANK.get(now, 1) > RANK.get(was, 1):
+        regressed.append((cid, was, now, br))
+    elif RANK.get(now, 1) < RANK.get(was, 1):
+        improved.append((cid, was, now, br))
+for cid, ar in ai.items():
+    if cid not in bi:
+        vanished.append((cid, ar))
+
+C = sys.stdout.isatty()
+RED    = "\033[0;31m" if C else ""
+GREEN  = "\033[0;32m" if C else ""
+YELLOW = "\033[1;33m" if C else ""
+CYAN   = "\033[0;36m" if C else ""
+BOLD   = "\033[1m"    if C else ""
+RST    = "\033[0m"    if C else ""
+
+def line(sym, colour, cid, text, extra=""):
+    print(f"  {colour}{sym}{RST}  {cid:<9} {text}")
+    if extra:
+        print(f"       {CYAN}{extra}{RST}")
+
+if quiet and not regressed:
+    sys.exit(0)
+
+if not quiet:
+    print()
+    print(f"{BOLD}{a.get('host','?')}{RST}   {a.get('date','?')}  →  {b.get('date','?')}")
+    sa, sb = a.get("score"), b.get("score")
+    if isinstance(sa, (int, float)) and isinstance(sb, (int, float)):
+        delta = sb - sa
+        col = GREEN if delta > 0 else (RED if delta < 0 else "")
+        print(f"{BOLD}score{RST}    {sa} → {sb}   {col}{delta:+d}{RST}")
+    print("─" * 68)
+
+if regressed:
+    print(f"\n  {RED}{BOLD}Regressed{RST}  ({len(regressed)})")
+    for cid, was, now, r in sorted(regressed, key=lambda x: -RANK.get(x[2], 0)):
+        line("✗", RED, cid, f"{was} → {now}   {r.get('check','')}", r.get("detail", ""))
+        if r.get("remediation"):
+            print(f"       {CYAN}fix{RST}  {r['remediation']}")
+
+if not quiet:
+    if appeared:
+        print(f"\n  {YELLOW}New and not passing{RST}  ({len(appeared)})")
+        for cid, r in appeared:
+            line("+", YELLOW, cid, f"{r.get('status')}   {r.get('check','')}", r.get("detail", ""))
+    if improved:
+        print(f"\n  {GREEN}Improved{RST}  ({len(improved)})")
+        for cid, was, now, r in improved:
+            line("✔", GREEN, cid, f"{was} → {now}   {r.get('check','')}")
+    if vanished:
+        print(f"\n  {CYAN}No longer reported{RST}  ({len(vanished)})")
+        for cid, r in vanished:
+            line("·", CYAN, cid, r.get("check", ""))
+    print("\n" + "─" * 68)
+    if regressed:
+        print(f"  {RED}{len(regressed)} regression(s){RST}, {len(improved)} improvement(s)\n")
+    else:
+        print(f"  {GREEN}Nothing regressed{RST}, {len(improved)} improvement(s)\n")
+
+sys.exit(1 if regressed else 0)
+PY
+}
+
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 main() {
   [[ $# -gt 0 ]] || { usage; exit 1; }
@@ -861,6 +1029,7 @@ main() {
     surface)        shift; cmd_surface "$@" ;;
     doctor)         shift; cmd_doctor "$@" ;;
     report)         shift; cmd_report "$@" ;;
+    diff)           shift; cmd_diff "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/aartool-src/cmd/diff.sh
+++ b/scripts/aartool-src/cmd/diff.sh
@@ -1,0 +1,166 @@
+# ── diff ─────────────────────────────────────────────────────────────────────
+# What changed between two audits of the same machine.
+#
+# This is the command that belongs in cron, and the reason is the exit code. A
+# weekly audit that mails you 109 results teaches you to filter the mail. One
+# that stays silent unless something REGRESSED is a thing you actually read.
+#
+#   aartool diff last-week.json today.json || mail -s "drift on $(hostname)" soc@
+#
+# Regressions and improvements are not symmetric here. A check going PASS to FAIL
+# is an alert; going FAIL to PASS is a note. Treating them the same is how a
+# report becomes wallpaper.
+
+cmd_diff_usage() {
+  cat <<'EOF'
+aartool diff — what changed between two audits. Changes nothing.
+
+Usage:
+  aartool diff BEFORE.json AFTER.json [options]
+
+Options:
+      --quiet     Print only regressions. Nothing at all when there are none,
+                  which is what you want in cron.
+  -h, --help      Show this help
+
+Exit codes:
+  0   nothing regressed
+  1   at least one check regressed
+  2   the reports could not be compared
+
+Built for cron:
+
+  aartool diff /var/log/cyberaar/last.json /var/log/cyberaar/today.json --quiet \
+    || mail -s "config drift on $(hostname)" soc@example.com
+EOF
+}
+
+cmd_diff() {
+  local quiet=false
+  local -a pos=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --quiet)   quiet=true; shift ;;
+      -h|--help) cmd_diff_usage; return 0 ;;
+      --) shift; while [[ $# -gt 0 ]]; do pos+=("$1"); shift; done ;;
+      -*) die "Unknown option for diff: $1. Try 'aartool diff --help'." ;;
+      *)  pos+=("$1"); shift ;;
+    esac
+  done
+
+  [[ "${#pos[@]}" -eq 2 ]] || die "diff needs exactly two reports: aartool diff BEFORE.json AFTER.json"
+  local before="${pos[0]}" after="${pos[1]}"
+  [[ -f "$before" ]] || die "No such report: $before"
+  [[ -f "$after"  ]] || die "No such report: $after"
+
+  command -v python3 >/dev/null 2>&1 \
+    || die "diff needs python3 to parse the reports. It is present on any machine that can run Ansible."
+
+  # Kept in python rather than jq: jq is not installed by default on RHEL,
+  # Ubuntu server or Alpine, and requiring it would put a package install between
+  # an operator and their own audit results.
+  python3 - "$before" "$after" "$quiet" <<'PY'
+import json, sys
+
+before_path, after_path, quiet = sys.argv[1], sys.argv[2], sys.argv[3] == "true"
+
+def load(p):
+    try:
+        with open(p, encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"[ERROR] Cannot read {p}: {e}\n"); sys.exit(2)
+    b = doc.get("cyberaar_baseline")
+    if not b:
+        sys.stderr.write(f"[ERROR] {p} is not a cyberaar-baseline report.\n"); sys.exit(2)
+    return b
+
+a, b = load(before_path), load(after_path)
+
+# Comparing two different machines silently would produce a diff that looks
+# real and means nothing.
+if a.get("host") and b.get("host") and a["host"] != b["host"]:
+    sys.stderr.write(
+        f"[ERROR] These are different hosts: '{a['host']}' and '{b['host']}'.\n"
+        f"        Comparing them would produce a difference that is not drift.\n")
+    sys.exit(2)
+
+RANK = {"PASS": 0, "WARN": 1, "FAIL": 2}
+def index(rep):
+    return {r["id"]: r for r in rep.get("results", []) if isinstance(r, dict) and "id" in r}
+
+ai, bi = index(a), index(b)
+
+regressed, improved, appeared, vanished = [], [], [], []
+for cid, br in bi.items():
+    ar = ai.get(cid)
+    if ar is None:
+        # A new check counts as drift only if it is already failing; a new
+        # passing check is just this tool having learned something.
+        if RANK.get(br.get("status"), 1) > 0:
+            appeared.append((cid, br))
+        continue
+    was, now = ar.get("status"), br.get("status")
+    if RANK.get(now, 1) > RANK.get(was, 1):
+        regressed.append((cid, was, now, br))
+    elif RANK.get(now, 1) < RANK.get(was, 1):
+        improved.append((cid, was, now, br))
+for cid, ar in ai.items():
+    if cid not in bi:
+        vanished.append((cid, ar))
+
+C = sys.stdout.isatty()
+RED    = "\033[0;31m" if C else ""
+GREEN  = "\033[0;32m" if C else ""
+YELLOW = "\033[1;33m" if C else ""
+CYAN   = "\033[0;36m" if C else ""
+BOLD   = "\033[1m"    if C else ""
+RST    = "\033[0m"    if C else ""
+
+def line(sym, colour, cid, text, extra=""):
+    print(f"  {colour}{sym}{RST}  {cid:<9} {text}")
+    if extra:
+        print(f"       {CYAN}{extra}{RST}")
+
+if quiet and not regressed:
+    sys.exit(0)
+
+if not quiet:
+    print()
+    print(f"{BOLD}{a.get('host','?')}{RST}   {a.get('date','?')}  →  {b.get('date','?')}")
+    sa, sb = a.get("score"), b.get("score")
+    if isinstance(sa, (int, float)) and isinstance(sb, (int, float)):
+        delta = sb - sa
+        col = GREEN if delta > 0 else (RED if delta < 0 else "")
+        print(f"{BOLD}score{RST}    {sa} → {sb}   {col}{delta:+d}{RST}")
+    print("─" * 68)
+
+if regressed:
+    print(f"\n  {RED}{BOLD}Regressed{RST}  ({len(regressed)})")
+    for cid, was, now, r in sorted(regressed, key=lambda x: -RANK.get(x[2], 0)):
+        line("✗", RED, cid, f"{was} → {now}   {r.get('check','')}", r.get("detail", ""))
+        if r.get("remediation"):
+            print(f"       {CYAN}fix{RST}  {r['remediation']}")
+
+if not quiet:
+    if appeared:
+        print(f"\n  {YELLOW}New and not passing{RST}  ({len(appeared)})")
+        for cid, r in appeared:
+            line("+", YELLOW, cid, f"{r.get('status')}   {r.get('check','')}", r.get("detail", ""))
+    if improved:
+        print(f"\n  {GREEN}Improved{RST}  ({len(improved)})")
+        for cid, was, now, r in improved:
+            line("✔", GREEN, cid, f"{was} → {now}   {r.get('check','')}")
+    if vanished:
+        print(f"\n  {CYAN}No longer reported{RST}  ({len(vanished)})")
+        for cid, r in vanished:
+            line("·", CYAN, cid, r.get("check", ""))
+    print("\n" + "─" * 68)
+    if regressed:
+        print(f"  {RED}{len(regressed)} regression(s){RST}, {len(improved)} improvement(s)\n")
+    else:
+        print(f"  {GREEN}Nothing regressed{RST}, {len(improved)} improvement(s)\n")
+
+sys.exit(1 if regressed else 0)
+PY
+}

--- a/scripts/aartool-src/main.sh
+++ b/scripts/aartool-src/main.sh
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="0.3.0"
+AARTOOL_VERSION="0.4.0"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -60,6 +60,7 @@ Commands:
               would still reach on this machine, and how to close it.
   doctor      Check everything plan and apply depend on.
   report      Visualise audit reports, or bake them into one shareable file.
+  diff        What changed between two audits. Exits non-zero on a regression.
 
 Global options:
   -h, --help        Show this help, or help for a command

--- a/scripts/aartool-src/run.sh
+++ b/scripts/aartool-src/run.sh
@@ -9,6 +9,7 @@ main() {
     surface)        shift; cmd_surface "$@" ;;
     doctor)         shift; cmd_doctor "$@" ;;
     report)         shift; cmd_report "$@" ;;
+    diff)           shift; cmd_diff "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/build-aartool.sh
+++ b/scripts/build-aartool.sh
@@ -22,6 +22,7 @@ PARTS=(
   aartool-src/cmd/surface.sh
   aartool-src/cmd/doctor.sh
   aartool-src/cmd/report.sh
+  aartool-src/cmd/diff.sh
   aartool-src/run.sh
 )
 

--- a/scripts/tests/test_aartool.sh
+++ b/scripts/tests/test_aartool.sh
@@ -141,6 +141,47 @@ fi
 check    "report rejects a missing file" "$($AARTOOL report /nonexistent.json 2>&1)" "No such report"
 check    "serve refuses a non-numeric port" "$($AARTOOL report --serve abc 2>&1)" "port number"
 
+# ── diff ─────────────────────────────────────────────────────────────────────
+if [[ -f "$_rep_src" ]]; then
+  # A regression and an improvement in the same pair, so the two are not
+  # confused with each other.
+  _d_after="$(mktemp -t aartool-after-XXXXXX.json)"
+  python3 - "$_rep_src" "$_d_after" <<'PYEOF' 2>/dev/null
+import json, sys
+d = json.load(open(sys.argv[1])); b = d["cyberaar_baseline"]
+b["date"] = "2099-01-01 00:00:00"; b["score"] = (b.get("score") or 50) - 7
+for r in b["results"]:
+    if r["id"] == "SSH-02": r["status"] = "FAIL"
+    if r["id"] == "LOG-01": r["status"] = "PASS"
+json.dump(d, open(sys.argv[2], "w"))
+PYEOF
+
+  if [[ -s "$_d_after" ]]; then
+    check    "diff names the regression" "$($AARTOOL diff "$_rep_src" "$_d_after" 2>&1)" "SSH-02"
+    check    "diff separates improvements" "$($AARTOOL diff "$_rep_src" "$_d_after" 2>&1)" "Improved"
+    # The exit code is the whole point in cron: 1 means something regressed.
+    check_rc "diff exits 1 on a regression" 1 "$AARTOOL" diff "$_rep_src" "$_d_after"
+    check_rc "diff exits 0 when nothing changed" 0 "$AARTOOL" diff "$_rep_src" "$_rep_src"
+    # --quiet must be genuinely silent, or cron mails you every week and you
+    # stop reading it.
+    check    "diff --quiet is silent when clean" "$($AARTOOL diff "$_rep_src" "$_rep_src" --quiet 2>&1)" ""
+    check    "diff --quiet still reports a regression" \
+             "$($AARTOOL diff "$_rep_src" "$_d_after" --quiet 2>&1)" "SSH-02"
+  fi
+
+  # Comparing two machines would produce a difference that is not drift.
+  _d_other="$(mktemp -t aartool-other-XXXXXX.json)"
+  sed 's|"host": *"[^"]*"|"host": "a-different-box"|' "$_rep_src" > "$_d_other"
+  check    "diff refuses two different hosts" "$($AARTOOL diff "$_rep_src" "$_d_other" 2>&1)" "different hosts"
+  check_rc "diff exits 2 when it cannot compare" 2 "$AARTOOL" diff "$_rep_src" "$_d_other"
+  rm -f "$_d_after" "$_d_other"
+fi
+
+echo '{"not":"a report"}' > /tmp/aartool-notreport.$$.json
+check    "diff rejects a non-report" "$($AARTOOL diff /tmp/aartool-notreport.$$.json /tmp/aartool-notreport.$$.json 2>&1)" "not a cyberaar-baseline report"
+rm -f /tmp/aartool-notreport.$$.json
+check    "diff needs two arguments" "$($AARTOOL diff one.json 2>&1)" "exactly two reports"
+
 # ── Per-command help ─────────────────────────────────────────────────────────
 check    "inspect help" "$($AARTOOL inspect --help 2>&1)" "Changes nothing"
 check    "plan help"    "$($AARTOOL plan --help 2>&1)"    "--target"
@@ -148,6 +189,7 @@ check    "apply help"   "$($AARTOOL apply --help 2>&1)"   "--yes"
 check    "surface help" "$($AARTOOL surface --help 2>&1)" "--strict"
 check    "doctor help"  "$($AARTOOL doctor --help 2>&1)"  "Changes nothing"
 check    "report help"  "$($AARTOOL report --help 2>&1)"  "self-contained"
+check    "diff help"    "$($AARTOOL diff --help 2>&1)"    "Exit codes"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
The audit produces 109 results. A weekly cron that mails all of them teaches you to filter the mail, and then nobody reads it. This is the other half:

```bash
aartool diff last-week.json today.json --quiet \
  || mail -s "config drift on $(hostname)" soc@example.com
```

| exit | meaning |
|---|---|
| `0` | nothing regressed |
| `1` | at least one check regressed |
| `2` | the reports could not be compared |

**The exit code is the feature.** `--quiet` prints nothing at all when nothing regressed. Silence is the answer you want most weeks, and it is what makes the alert mean something on the week it arrives.

## Regressions and improvements are not symmetric

PASS to FAIL is an alert and prints first, with the remediation. FAIL to PASS is a note at the bottom. A tool that reports both with equal weight produces a paragraph nobody reads, with the regression in the middle of it.

**A newly appearing check counts as drift only if it is already failing.** A new passing check is this toolkit having learned something, not the machine having changed — reporting it as drift would cry wolf on every upgrade.

## It refuses to compare two different hosts

A diff between two machines looks exactly like drift and is not. Given reports with different hostnames it exits 2 and says so, rather than producing a convincing page of differences that mean nothing.

## python3 rather than jq

Deliberate: jq is not installed by default on RHEL, Ubuntu Server or Alpine, and putting a package install between an operator and their own audit results is how a tool goes unused. python3 is already required by Ansible.

48 tests. **The exit codes are asserted, not just the output**, because they are the contract cron depends on — including that `--quiet` produces genuinely empty output on a clean comparison.