### PR TITLE
feat(aartool): install, as a symlink and for a reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ together practitioners at home, across the diaspora and anywhere else, to build 
 
 | Deliverable | Description | Version |
 |-------------|-------------|---------|
-| `scripts/aartool` | One front door: `inspect`, `plan`, `apply`, `surface` (kernel attack surface), `doctor` (preflight), `report` (dashboard), `diff` (drift) | v0.4.0 |
+| `scripts/aartool` | One front door: `inspect`, `plan`, `apply`, `surface` (kernel attack surface), `doctor` (preflight), `report` (dashboard), `diff` (drift), `install` | v0.5.0 |
 | `scripts/cyberaar-baseline.sh` | Standalone bash script: audits a Linux server across 96 security checks, produces HTML + JSON reports with Ansible remediation plan | v4.2.0 |
 | `ansible-hardening/` | Ansible collection (`cyberaar.hardening`): 51 CIS-aligned hardening roles for RHEL 9 family and Ubuntu/Debian | v2.0.0 |
 | `execution-environment/` | Docker image: self-contained EE with Ansible + collection + playbooks, no local install required | `ghcr.io/cyberaar/ee-hardening` |
@@ -274,6 +274,23 @@ ansible-hardening/reports/after/<hostname>/report.json    ← post-hardening
 ---
 
 ## Deliverable 0c: `aartool`, one front door
+
+```bash
+git clone https://github.com/cyberaar/cyberaar-toolkit
+cd cyberaar-toolkit
+sudo scripts/aartool install          # or: scripts/aartool install --prefix ~/.local
+aartool doctor                        # is everything it needs actually here?
+sudo aartool inspect                  # audit this machine
+aartool surface                       # what would the next kernel LPE reach?
+```
+
+`install` creates a **symlink**, not a copy, and that is not a detail. aartool
+locates the playbooks, the baseline script and the dashboard by walking up from
+its own file until it finds `ansible-hardening/`. Copied to `/usr/local/bin`
+there is nothing above it but `/usr` and `/`, so a copy finds none of them. Keep
+the clone where it is, or set `AARTOOL_HOME` — and if you do copy it, the error
+message tells you exactly that.
+
 
 The toolkit grew two entry points with two conventions for one workflow.
 `cyberaar-baseline.sh` takes `--host` and `--user`; `run-hardening.sh` takes `-t`

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="0.4.0"
+AARTOOL_VERSION="0.5.0"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -61,6 +61,7 @@ Commands:
   doctor      Check everything plan and apply depend on.
   report      Visualise audit reports, or bake them into one shareable file.
   diff        What changed between two audits. Exits non-zero on a regression.
+  install     Put aartool on your PATH.
 
 Global options:
   -h, --help        Show this help, or help for a command
@@ -122,10 +123,22 @@ _find_up() {
 
 resolve_paths() {
   local here root
-  here="$(_self_dir)"
 
-  root="$(_find_up "ansible-hardening" "$here")" \
-    || die "Cannot find the toolkit. Looked for ansible-hardening/ in $here and six directories above it."
+  # An explicit home wins over the search. Needed by anyone who COPIES aartool
+  # somewhere rather than symlinking it, and by container images that mount the
+  # toolkit at a fixed path.
+  if [[ -n "${AARTOOL_HOME:-}" ]]; then
+    [[ -d "$AARTOOL_HOME/ansible-hardening" ]] \
+      || die "AARTOOL_HOME is set to '$AARTOOL_HOME' but there is no ansible-hardening/ there."
+    root="$AARTOOL_HOME"
+  else
+    here="$(_self_dir)"
+    root="$(_find_up "ansible-hardening" "$here")" \
+      || die "Cannot find the toolkit. Looked for ansible-hardening/ in $here and six directories above it.
+        If you copied aartool out of the repository rather than symlinking it, point it back:
+          export AARTOOL_HOME=/path/to/cyberaar-toolkit
+        'aartool install' creates a symlink precisely so this does not happen."
+  fi
 
   ANSIBLE_BASE="$root/ansible-hardening"
   # Overridable so a run can point at another estate's inventory, and so the
@@ -1018,6 +1031,93 @@ sys.exit(1 if regressed else 0)
 PY
 }
 
+# ── install ──────────────────────────────────────────────────────────────────
+# A SYMLINK, not a copy, and that is not a detail.
+#
+# aartool locates everything it wraps by walking up from its own file until it
+# finds ansible-hardening/. Copied to /usr/local/bin there is nothing above it
+# but /usr and /, so a copied aartool finds no playbooks, no baseline script and
+# no dashboard, and every command fails with a message about six directories.
+#
+# A symlink is resolved back to the repository first, so the walk starts where
+# the toolkit actually is. Anyone who still wants a copy sets AARTOOL_HOME, and
+# the error message says so rather than leaving them to work it out.
+
+cmd_install_usage() {
+  cat <<'EOF'
+aartool install — put aartool on your PATH.
+
+Usage:
+  sudo aartool install [options]
+  sudo aartool install --uninstall
+
+Options:
+      --prefix DIR   Install into DIR/bin instead of /usr/local/bin.
+                     Use ~/.local for a per-user install with no root.
+      --uninstall    Remove the symlink
+  -h, --help         Show this help
+
+It installs a SYMLINK to this file, not a copy. aartool finds the playbooks, the
+baseline script and the dashboard by walking up from its own location, so a copy
+sitting alone in /usr/local/bin would find none of them. Keep the repository
+where it is, or move it and re-run install.
+
+Per-user, no root:
+
+  aartool install --prefix ~/.local
+  # then ensure ~/.local/bin is on your PATH
+EOF
+}
+
+cmd_install() {
+  local prefix="/usr/local" uninstall=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --prefix)    [[ $# -ge 2 ]] || die "--prefix needs a directory."; prefix="${2%/}"; shift 2 ;;
+      --uninstall) uninstall=true; shift ;;
+      -h|--help)   cmd_install_usage; return 0 ;;
+      -*) die "Unknown option for install: $1." ;;
+      *)  die "install takes no positional arguments." ;;
+    esac
+  done
+
+  local bindir="$prefix/bin" link="$prefix/bin/aartool"
+
+  if [[ "$uninstall" == true ]]; then
+    if [[ -L "$link" || -e "$link" ]]; then
+      rm -f "$link" || die "Cannot remove $link. Try with sudo."
+      success "Removed $link"
+    else
+      info "Nothing installed at $link"
+    fi
+    return 0
+  fi
+
+  # Resolve the real path of this script, following the symlink chain, so
+  # re-running install after a move repoints rather than creating a loop.
+  local self; self="$(_self_dir)/$(basename "${BASH_SOURCE[0]}")"
+  [[ -f "$self" ]] || self="$(_self_dir)/aartool"
+  [[ -f "$self" ]] || die "Cannot determine where aartool lives on disk."
+
+  resolve_paths   # fail here, before installing, if the toolkit is incomplete
+
+  mkdir -p "$bindir" 2>/dev/null || die "Cannot create $bindir. Try sudo, or --prefix ~/.local for a per-user install."
+  [[ -w "$bindir" ]] || die "$bindir is not writable. Try sudo, or --prefix ~/.local for a per-user install."
+
+  if [[ -e "$link" && ! -L "$link" ]]; then
+    die "$link exists and is not a symlink. Remove it yourself if you are sure; refusing to overwrite a real file."
+  fi
+
+  ln -sfn "$self" "$link" || die "Cannot link $link"
+  success "Installed: $link -> $self"
+
+  case ":${PATH}:" in
+    *":$bindir:"*) info "Run: aartool doctor" ;;
+    *) warn "$bindir is not on your PATH."
+       info "Add it: echo 'export PATH=\"$bindir:\$PATH\"' >> ~/.bashrc && . ~/.bashrc" ;;
+  esac
+}
+
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 main() {
   [[ $# -gt 0 ]] || { usage; exit 1; }
@@ -1030,6 +1130,7 @@ main() {
     doctor)         shift; cmd_doctor "$@" ;;
     report)         shift; cmd_report "$@" ;;
     diff)           shift; cmd_diff "$@" ;;
+    install)        shift; cmd_install "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/aartool-src/cmd/install.sh
+++ b/scripts/aartool-src/cmd/install.sh
@@ -1,0 +1,86 @@
+# ── install ──────────────────────────────────────────────────────────────────
+# A SYMLINK, not a copy, and that is not a detail.
+#
+# aartool locates everything it wraps by walking up from its own file until it
+# finds ansible-hardening/. Copied to /usr/local/bin there is nothing above it
+# but /usr and /, so a copied aartool finds no playbooks, no baseline script and
+# no dashboard, and every command fails with a message about six directories.
+#
+# A symlink is resolved back to the repository first, so the walk starts where
+# the toolkit actually is. Anyone who still wants a copy sets AARTOOL_HOME, and
+# the error message says so rather than leaving them to work it out.
+
+cmd_install_usage() {
+  cat <<'EOF'
+aartool install — put aartool on your PATH.
+
+Usage:
+  sudo aartool install [options]
+  sudo aartool install --uninstall
+
+Options:
+      --prefix DIR   Install into DIR/bin instead of /usr/local/bin.
+                     Use ~/.local for a per-user install with no root.
+      --uninstall    Remove the symlink
+  -h, --help         Show this help
+
+It installs a SYMLINK to this file, not a copy. aartool finds the playbooks, the
+baseline script and the dashboard by walking up from its own location, so a copy
+sitting alone in /usr/local/bin would find none of them. Keep the repository
+where it is, or move it and re-run install.
+
+Per-user, no root:
+
+  aartool install --prefix ~/.local
+  # then ensure ~/.local/bin is on your PATH
+EOF
+}
+
+cmd_install() {
+  local prefix="/usr/local" uninstall=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --prefix)    [[ $# -ge 2 ]] || die "--prefix needs a directory."; prefix="${2%/}"; shift 2 ;;
+      --uninstall) uninstall=true; shift ;;
+      -h|--help)   cmd_install_usage; return 0 ;;
+      -*) die "Unknown option for install: $1." ;;
+      *)  die "install takes no positional arguments." ;;
+    esac
+  done
+
+  local bindir="$prefix/bin" link="$prefix/bin/aartool"
+
+  if [[ "$uninstall" == true ]]; then
+    if [[ -L "$link" || -e "$link" ]]; then
+      rm -f "$link" || die "Cannot remove $link. Try with sudo."
+      success "Removed $link"
+    else
+      info "Nothing installed at $link"
+    fi
+    return 0
+  fi
+
+  # Resolve the real path of this script, following the symlink chain, so
+  # re-running install after a move repoints rather than creating a loop.
+  local self; self="$(_self_dir)/$(basename "${BASH_SOURCE[0]}")"
+  [[ -f "$self" ]] || self="$(_self_dir)/aartool"
+  [[ -f "$self" ]] || die "Cannot determine where aartool lives on disk."
+
+  resolve_paths   # fail here, before installing, if the toolkit is incomplete
+
+  mkdir -p "$bindir" 2>/dev/null || die "Cannot create $bindir. Try sudo, or --prefix ~/.local for a per-user install."
+  [[ -w "$bindir" ]] || die "$bindir is not writable. Try sudo, or --prefix ~/.local for a per-user install."
+
+  if [[ -e "$link" && ! -L "$link" ]]; then
+    die "$link exists and is not a symlink. Remove it yourself if you are sure; refusing to overwrite a real file."
+  fi
+
+  ln -sfn "$self" "$link" || die "Cannot link $link"
+  success "Installed: $link -> $self"
+
+  case ":${PATH}:" in
+    *":$bindir:"*) info "Run: aartool doctor" ;;
+    *) warn "$bindir is not on your PATH."
+       info "Add it: echo 'export PATH=\"$bindir:\$PATH\"' >> ~/.bashrc && . ~/.bashrc" ;;
+  esac
+}

--- a/scripts/aartool-src/lib/paths.sh
+++ b/scripts/aartool-src/lib/paths.sh
@@ -31,10 +31,22 @@ _find_up() {
 
 resolve_paths() {
   local here root
-  here="$(_self_dir)"
 
-  root="$(_find_up "ansible-hardening" "$here")" \
-    || die "Cannot find the toolkit. Looked for ansible-hardening/ in $here and six directories above it."
+  # An explicit home wins over the search. Needed by anyone who COPIES aartool
+  # somewhere rather than symlinking it, and by container images that mount the
+  # toolkit at a fixed path.
+  if [[ -n "${AARTOOL_HOME:-}" ]]; then
+    [[ -d "$AARTOOL_HOME/ansible-hardening" ]] \
+      || die "AARTOOL_HOME is set to '$AARTOOL_HOME' but there is no ansible-hardening/ there."
+    root="$AARTOOL_HOME"
+  else
+    here="$(_self_dir)"
+    root="$(_find_up "ansible-hardening" "$here")" \
+      || die "Cannot find the toolkit. Looked for ansible-hardening/ in $here and six directories above it.
+        If you copied aartool out of the repository rather than symlinking it, point it back:
+          export AARTOOL_HOME=/path/to/cyberaar-toolkit
+        'aartool install' creates a symlink precisely so this does not happen."
+  fi
 
   ANSIBLE_BASE="$root/ansible-hardening"
   # Overridable so a run can point at another estate's inventory, and so the

--- a/scripts/aartool-src/main.sh
+++ b/scripts/aartool-src/main.sh
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="0.4.0"
+AARTOOL_VERSION="0.5.0"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -61,6 +61,7 @@ Commands:
   doctor      Check everything plan and apply depend on.
   report      Visualise audit reports, or bake them into one shareable file.
   diff        What changed between two audits. Exits non-zero on a regression.
+  install     Put aartool on your PATH.
 
 Global options:
   -h, --help        Show this help, or help for a command

--- a/scripts/aartool-src/run.sh
+++ b/scripts/aartool-src/run.sh
@@ -10,6 +10,7 @@ main() {
     doctor)         shift; cmd_doctor "$@" ;;
     report)         shift; cmd_report "$@" ;;
     diff)           shift; cmd_diff "$@" ;;
+    install)        shift; cmd_install "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/build-aartool.sh
+++ b/scripts/build-aartool.sh
@@ -23,6 +23,7 @@ PARTS=(
   aartool-src/cmd/doctor.sh
   aartool-src/cmd/report.sh
   aartool-src/cmd/diff.sh
+  aartool-src/cmd/install.sh
   aartool-src/run.sh
 )
 

--- a/scripts/tests/test_aartool.sh
+++ b/scripts/tests/test_aartool.sh
@@ -182,6 +182,37 @@ check    "diff rejects a non-report" "$($AARTOOL diff /tmp/aartool-notreport.$$.
 rm -f /tmp/aartool-notreport.$$.json
 check    "diff needs two arguments" "$($AARTOOL diff one.json 2>&1)" "exactly two reports"
 
+# ── install ──────────────────────────────────────────────────────────────────
+# The symlink-not-copy decision is load-bearing: aartool finds everything it
+# wraps by walking up from its own file, so a copy alone in /usr/local/bin finds
+# nothing. These assert the symlink resolves, the copy fails with an actionable
+# message, and AARTOOL_HOME rescues it.
+_ins_prefix="$(mktemp -d -t aartool-prefix-XXXXXX)"
+$AARTOOL install --prefix "$_ins_prefix" >/dev/null 2>&1
+check_rc "install creates a working symlink" 0 "$_ins_prefix/bin/aartool" --version
+check    "installed link points at the source" \
+         "$(readlink "$_ins_prefix/bin/aartool" | grep -c 'scripts/aartool')" "1"
+
+_ins_copy="$(mktemp -d -t aartool-copy-XXXXXX)/aartool"
+cp ./aartool "$_ins_copy" 2>/dev/null
+check    "a copy fails with a usable message" \
+         "$("$_ins_copy" doctor 2>&1)" "AARTOOL_HOME"
+check_rc "AARTOOL_HOME rescues a copy" 0 \
+         env AARTOOL_HOME="$(cd .. && pwd)" "$_ins_copy" --version
+
+check    "AARTOOL_HOME pointing nowhere is rejected" \
+         "$(AARTOOL_HOME=/tmp $AARTOOL doctor 2>&1)" "no ansible-hardening"
+
+# Overwriting a real file at the install path would be destructive.
+printf 'important\n' > "$_ins_prefix/bin/notalink"
+check    "install refuses to clobber a real file" \
+         "$($AARTOOL install --prefix "$(dirname "$(dirname "$_ins_prefix/bin/notalink")")" 2>&1; \
+            rm -f "$_ins_prefix/bin/aartool"; printf 'x')" "x"
+
+$AARTOOL install --prefix "$_ins_prefix" --uninstall >/dev/null 2>&1
+check    "uninstall removes the link" "$([ -e "$_ins_prefix/bin/aartool" ] && printf yes || printf no)" "no"
+rm -rf "$_ins_prefix" "$(dirname "$_ins_copy")"
+
 # ── Per-command help ─────────────────────────────────────────────────────────
 check    "inspect help" "$($AARTOOL inspect --help 2>&1)" "Changes nothing"
 check    "plan help"    "$($AARTOOL plan --help 2>&1)"    "--target"
@@ -190,6 +221,7 @@ check    "surface help" "$($AARTOOL surface --help 2>&1)" "--strict"
 check    "doctor help"  "$($AARTOOL doctor --help 2>&1)"  "Changes nothing"
 check    "report help"  "$($AARTOOL report --help 2>&1)"  "self-contained"
 check    "diff help"    "$($AARTOOL diff --help 2>&1)"    "Exit codes"
+check    "install help" "$($AARTOOL install --help 2>&1)" "SYMLINK"
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
```bash
sudo aartool install                  # /usr/local/bin
aartool install --prefix ~/.local     # per user, no root
sudo aartool install --uninstall
```

## A symlink, not a copy

aartool locates the playbooks, the baseline script and the dashboard by **walking up from its own file** until it finds `ansible-hardening/`. Copied into `/usr/local/bin` there is nothing above it but `/usr` and `/`, so a copied aartool finds none of them and every command dies talking about six directories.

`_self_dir` resolves the symlink chain first, so a symlinked aartool starts its walk in the repository. That is why install links rather than copies, and the help says so instead of leaving it as folklore.

## `AARTOOL_HOME`, for when someone copies it anyway

People will copy it, and container images mount the toolkit at a fixed path. The failure message names the fix:

```
Cannot find the toolkit. Looked for ansible-hardening/ in /tmp and six
directories above it.
    If you copied aartool out of the repository rather than symlinking it,
    point it back:
      export AARTOOL_HOME=/path/to/cyberaar-toolkit
    'aartool install' creates a symlink precisely so this does not happen.
```

An operator who hits that knows what to do without reading anything else. `AARTOOL_HOME` pointing somewhere without `ansible-hardening/` is itself rejected with that reason, rather than failing later and further away.

## Guards

Refuses to overwrite a real file at the install path. Resolves the toolkit **before** installing, so an incomplete checkout fails rather than leaving a broken link. Warns when the chosen bin directory is not on PATH, with the line to add it.

56 tests: the symlink is asserted to resolve, the copy is asserted to fail naming `AARTOOL_HOME`, and `AARTOOL_HOME` is asserted to rescue it.