### PR TITLE
fix(scan): the remote audit could not work on a hardened host, and said it did

### DIFF
--- a/scripts/aartool
+++ b/scripts/aartool
@@ -263,6 +263,9 @@ Options:
   --inventory FILE      Audit every host in an Ansible inventory
   --user USER           SSH user for a remote audit
   --ssh-key FILE        SSH private key for a remote audit
+  --ssh-opt OPT         Extra ssh option, repeatable. For a host behind a
+                        bastion, which is most of them:
+                          --ssh-opt '-J admin@bastion.example.com'
   -o, --out DIR         Write reports to DIR (HTML and JSON)
   -h, --help            Show this help
 
@@ -282,7 +285,7 @@ cmd_inspect() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --host|--host-file|--inventory|--user|--ssh-key)
+      --host|--host-file|--inventory|--user|--ssh-key|--ssh-opt)
         [[ $# -ge 2 ]] || die "$1 needs a value."
         passthru+=("$1" "$2"); shift 2 ;;
       -o|--out)

--- a/scripts/aartool-src/cmd/inspect.sh
+++ b/scripts/aartool-src/cmd/inspect.sh
@@ -16,6 +16,9 @@ Options:
   --inventory FILE      Audit every host in an Ansible inventory
   --user USER           SSH user for a remote audit
   --ssh-key FILE        SSH private key for a remote audit
+  --ssh-opt OPT         Extra ssh option, repeatable. For a host behind a
+                        bastion, which is most of them:
+                          --ssh-opt '-J admin@bastion.example.com'
   -o, --out DIR         Write reports to DIR (HTML and JSON)
   -h, --help            Show this help
 
@@ -35,7 +38,7 @@ cmd_inspect() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --host|--host-file|--inventory|--user|--ssh-key)
+      --host|--host-file|--inventory|--user|--ssh-key|--ssh-opt)
         [[ $# -ge 2 ]] || die "$1 needs a value."
         passthru+=("$1" "$2"); shift 2 ;;
       -o|--out)

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -36,6 +36,8 @@ Remote / Fleet options:
   --inventory <file>     Parse an Ansible inventory file for hosts
   --user <user>          SSH user for remote scan (default: root)
   --ssh-key <keyfile>    SSH private key for remote scan
+  --ssh-opt <opt>        Extra ssh option, repeatable. For a bastion:
+                           --ssh-opt '-J admin@bastion.example.com' 
   --ansible-dir <dir>    Path to your Ansible repo (for playbook suggestions)
 
 Install options:
@@ -69,6 +71,10 @@ HELPEOF
 # ─── CLI ARGS ────────────────────────────────────────────────────────────────
 HTML_OUT=""
 JSON_OUT=""
+# Declared before the parse loop: += on an undeclared name is an error under
+# set -u, which would make the flag unusable rather than merely wrong.
+REMOTE_SSH_OPTS=()
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --html-out)       HTML_OUT="$2";        shift 2 ;;
@@ -77,6 +83,10 @@ while [[ $# -gt 0 ]]; do
     --inventory)      ANSIBLE_INVENTORY="$2";shift 2 ;;
     --user)           REMOTE_USER="$2";     shift 2 ;;
     --ssh-key)        REMOTE_KEY="$2";      shift 2 ;;
+    # Repeatable, and word-split on purpose so --ssh-opt '-J host' and
+    # --ssh-opt -J --ssh-opt host both work.
+    # shellcheck disable=SC2206
+    --ssh-opt)        REMOTE_SSH_OPTS+=($2); shift 2 ;;
     --ansible-dir)    ANSIBLE_DIR="$2";     shift 2 ;;
     --json-out)   JSON_OUT="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
@@ -377,7 +387,49 @@ _build_host_list() {
   printf '%s\n' "${out[@]}"
 }
 
+# Shared directory for the ssh control sockets, private to this run. Removed on
+# exit along with any master connections still persisting, so a scan leaves no
+# open sessions behind on the operator's machine.
+_CYBERAAR_SSH_CTL_DIR=""
+_cyberaar_ssh_ctl_init() {
+  _CYBERAAR_SSH_CTL_DIR="$(mktemp -d -t cyberaar-ssh-XXXXXX 2>/dev/null)" || _CYBERAAR_SSH_CTL_DIR=""
+  [[ -n "$_CYBERAAR_SSH_CTL_DIR" ]] && chmod 700 "$_CYBERAAR_SSH_CTL_DIR" 2>/dev/null || true
+}
+_cyberaar_ssh_ctl_cleanup() {
+  [[ -n "$_CYBERAAR_SSH_CTL_DIR" && -d "$_CYBERAAR_SSH_CTL_DIR" ]] || return 0
+  local sock
+  for sock in "$_CYBERAAR_SSH_CTL_DIR"/*; do
+    [[ -S "$sock" ]] && ssh -o ControlPath="$sock" -O exit placeholder &>/dev/null || true
+  done
+  rm -rf "$_CYBERAAR_SSH_CTL_DIR"
+  _CYBERAAR_SSH_CTL_DIR=""
+}
+trap _cyberaar_ssh_ctl_cleanup EXIT INT TERM
+
 # ── Run scan on a single remote host via SSH ──────────────────────────────────
+#
+# TRANSPORT: ssh with the file on stdin, not scp.
+#
+# scp in OpenSSH 9 and later speaks the SFTP protocol by default, and a hardened
+# host frequently has no sftp subsystem at all: removing it is a normal CIS and
+# STIG hardening step, and this toolkit's own ssh role is the kind of thing that
+# does it. The result was that the remote scan failed on exactly the hosts most
+# likely to be running a security tool, with
+#
+#     scp: Connection closed
+#
+# swallowed by 2>/dev/null, then "bash: /tmp/.cyberaar-baseline-xxx.sh: No such
+# file or directory" from the run that followed, and a cheerful "1 succeeded" at
+# the end. Found on a live bastion, not in review.
+#
+# Piping over an ssh session needs no subsystem, no scp binary and no sftp, so it
+# works wherever an interactive command works. `cat > file` is also the only
+# transport available when a host allows command execution but no file transfer.
+#
+# EVERY STEP IS CHECKED. The previous version returned success unless the initial
+# connectivity probe failed, so a scan that copied nothing, ran nothing and
+# fetched nothing still counted as a success in the fleet summary. A scanner that
+# cannot tell you it failed is worse than one that is simply absent.
 _remote_scan() {
   local host="$1"
   local html_out="$2"
@@ -385,49 +437,129 @@ _remote_scan() {
 
   local ssh_opts=(-o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o BatchMode=yes)
   [[ -n "$REMOTE_KEY" ]] && ssh_opts+=(-i "$REMOTE_KEY")
+
+  # One TCP connection per host, reused for all seven operations below.
+  #
+  # A scan opens a connection to probe, to push the script, to check it landed,
+  # to run it, to fetch each report and to clean up. Without multiplexing that is
+  # seven full handshakes per host, so a fifty-host fleet performs three hundred
+  # and fifty. That is slow, it pushes against sshd's MaxStartups (10:30:100 by
+  # default, past which it refuses roughly a third of new connections at random),
+  # and on a host running fail2ban it looks like exactly the thing fail2ban is
+  # there to stop.
+  #
+  # Found the hard way: scanning one host repeatedly during development got this
+  # workstation banned by the estate's own fail2ban.
+  #
+  # %C hashes host, port, user and local host into a short filename, which keeps
+  # the socket path under the 104-byte sun_path limit that longer schemes hit.
+  if [[ -n "$_CYBERAAR_SSH_CTL_DIR" ]]; then
+    ssh_opts+=(-o ControlMaster=auto -o "ControlPath=${_CYBERAAR_SSH_CTL_DIR}/%C" -o ControlPersist=30s)
+  fi
+  # Anything the operator passed with --ssh-opt, most usefully -J for a bastion.
+  # Estates that matter put their hosts behind a jump host, and without this the
+  # scanner could only reach machines that were already reachable directly.
+  local _o
+  for _o in ${REMOTE_SSH_OPTS[@]+"${REMOTE_SSH_OPTS[@]}"}; do ssh_opts+=("$_o"); done
+
   local target="${REMOTE_USER}@${host}"
   local _rand
   _rand=$(openssl rand -hex 8 2>/dev/null || tr -dc 'a-f0-9' < /dev/urandom 2>/dev/null | head -c 16)
   local remote_script="/tmp/.cyberaar-baseline-${_rand}.sh"
+  local remote_html="/tmp/.cyberaar-report-${_rand}.html"
+  local remote_json="/tmp/.cyberaar-report-${_rand}.json"
 
   printf "\n${BOLD}${CYAN}━━━  Remote scan: %s  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n" "$host"
 
-  # Test SSH connectivity first
-  if ! ssh "${ssh_opts[@]}" "$target" "echo ok" &>/dev/null; then
+  # ── 1. Reachability ────────────────────────────────────────────────────────
+  local _probe
+  if ! _probe=$(ssh "${ssh_opts[@]}" "$target" "echo ok" 2>&1); then
     printf "  ${RED}❌  SSH connection failed: %s@%s${NC}\n" "$REMOTE_USER" "$host"
-    printf "     Check: host reachable, user exists, key/password auth works.\n"
+    printf "     %s\n" "${_probe%%$'\n'*}"
+    printf "     Check: host reachable, user exists, key auth works without a passphrase.\n"
+    printf "     Behind a bastion? Pass it through: --ssh-opt '-J user@bastion'\n"
     return 1
   fi
 
-  # Copy script to remote
-  scp "${ssh_opts[@]/#-o/-o}" -q "$SCRIPT_PATH" "${target}:${remote_script}" 2>/dev/null
-
-  # Build remote flags
-  local rflags=""
-  [[ -n "$html_out" ]] && rflags="$rflags --html-out /tmp/.cyberaar-report-${_rand}.html"
-  [[ -n "$json_out" ]] && rflags="$rflags --json-out /tmp/.cyberaar-report-${_rand}.json"
-
-  # Execute on remote (always needs root — try sudo if not root user)
-  if [[ "$REMOTE_USER" == "root" ]]; then
-    ssh "${ssh_opts[@]}" "$target" "bash '${remote_script}'${rflags:+ $rflags}" || true
-  else
-    ssh "${ssh_opts[@]}" "$target" "sudo bash '${remote_script}'${rflags:+ $rflags}" || true
+  # ── 2. Push the script ─────────────────────────────────────────────────────
+  local _err
+  if ! _err=$(ssh "${ssh_opts[@]}" "$target" \
+        "cat > '${remote_script}' && chmod 700 '${remote_script}'" < "$SCRIPT_PATH" 2>&1); then
+    printf "  ${RED}❌  Could not copy the audit script to %s${NC}\n" "$host"
+    printf "     %s\n" "${_err%%$'\n'*}"
+    printf "     The remote /tmp may be full, noexec, or read-only.\n"
+    return 1
   fi
 
-  # Retrieve reports
+  # Landed and non-empty. A truncated copy runs and produces nonsense.
+  local _size
+  _size=$(ssh "${ssh_opts[@]}" "$target" "wc -c < '${remote_script}' 2>/dev/null || echo 0" 2>/dev/null | tr -dc '0-9')
+  if [[ -z "$_size" || "$_size" -lt 1000 ]]; then
+    printf "  ${RED}❌  The audit script did not arrive intact on %s (%s bytes)${NC}\n" "$host" "${_size:-0}"
+    ssh "${ssh_opts[@]}" "$target" "rm -f '${remote_script}'" &>/dev/null || true
+    return 1
+  fi
+
+  # ── 3. Run it ──────────────────────────────────────────────────────────────
+  local rflags=""
+  [[ -n "$html_out" ]] && rflags="$rflags --html-out ${remote_html}"
+  [[ -n "$json_out" ]] && rflags="$rflags --json-out ${remote_json}"
+
+  local _rc=0
+  if [[ "$REMOTE_USER" == "root" ]]; then
+    ssh "${ssh_opts[@]}" "$target" "bash '${remote_script}'${rflags:+ $rflags}" || _rc=$?
+  else
+    # -n so the remote sudo cannot silently wait for a password nobody can type.
+    ssh "${ssh_opts[@]}" "$target" "sudo -n bash '${remote_script}'${rflags:+ $rflags}" || _rc=$?
+  fi
+  if [[ "$_rc" -ne 0 ]]; then
+    printf "  ${RED}❌  The audit did not complete on %s (exit %d)${NC}\n" "$host" "$_rc"
+    printf "     If this is a sudo prompt: %s needs passwordless sudo, or scan as root.\n" "$REMOTE_USER"
+    ssh "${ssh_opts[@]}" "$target" "rm -f '${remote_script}' '${remote_html}' '${remote_json}'" &>/dev/null || true
+    return 1
+  fi
+
+  # ── 4. Fetch the reports ───────────────────────────────────────────────────
+  # Same reasoning as the push: cat over ssh needs no sftp. An empty file counts
+  # as a failure, because a zero-byte report reads as a successful scan of a
+  # machine with no findings.
+  #
+  # Read back through sudo when the scan ran through sudo. The audit runs as root
+  # and writes its reports as root, so an unprivileged login cannot read the
+  # files it just asked for. That failed silently on a live host: the audit
+  # completed, printed its findings to the terminal, and then could not retrieve
+  # a single one of them.
+  local _cat="cat"
+  [[ "$REMOTE_USER" != "root" ]] && _cat="sudo -n cat"
+  local fetch_failed=0
   if [[ -n "$html_out" ]]; then
-    scp "${ssh_opts[@]/#-o/-o}" -q "${target}:/tmp/.cyberaar-report-${_rand}.html" "$html_out" 2>/dev/null \
-      && printf "  🌐 HTML fetched → %s\n" "$html_out" \
-      || printf "  ${YELLOW}⚠️   Could not fetch HTML report from %s${NC}\n" "$host"
+    if ssh "${ssh_opts[@]}" "$target" "$_cat '${remote_html}'" > "$html_out" 2>/dev/null && [[ -s "$html_out" ]]; then
+      printf "  🌐 HTML fetched → %s\n" "$html_out"
+    else
+      rm -f "$html_out"
+      printf "  ${YELLOW}⚠️   Could not fetch the HTML report from %s${NC}\n" "$host"
+      fetch_failed=1
+    fi
   fi
   if [[ -n "$json_out" ]]; then
-    scp "${ssh_opts[@]/#-o/-o}" -q "${target}:/tmp/.cyberaar-report-${_rand}.json" "$json_out" 2>/dev/null \
-      && printf "  📄 JSON fetched → %s\n" "$json_out" \
-      || printf "  ${YELLOW}⚠️   Could not fetch JSON report from %s${NC}\n" "$host"
+    if ssh "${ssh_opts[@]}" "$target" "$_cat '${remote_json}'" > "$json_out" 2>/dev/null && [[ -s "$json_out" ]]; then
+      printf "  📄 JSON fetched → %s\n" "$json_out"
+    else
+      rm -f "$json_out"
+      printf "  ${YELLOW}⚠️   Could not fetch the JSON report from %s${NC}\n" "$host"
+      fetch_failed=1
+    fi
   fi
 
-  # Cleanup remote temp files
-  ssh "${ssh_opts[@]}" "$target" "rm -f '${remote_script}' '/tmp/.cyberaar-report-${_rand}.html' '/tmp/.cyberaar-report-${_rand}.json'" &>/dev/null || true
+  # ── 5. Clean up after ourselves ────────────────────────────────────────────
+  # Root-owned reports need root to remove. Leaving an audit of the machine in
+  # world-readable /tmp is not acceptable housekeeping for a security tool.
+  local _rm="rm -f"
+  [[ "$REMOTE_USER" != "root" ]] && _rm="sudo -n rm -f"
+  ssh "${ssh_opts[@]}" "$target" "$_rm '${remote_script}' '${remote_html}' '${remote_json}'" &>/dev/null || true
+
+  [[ "$fetch_failed" -eq 0 ]] || return 1
+  return 0
 }
 
 # ── Fleet scan dispatcher ─────────────────────────────────────────────────────
@@ -446,6 +578,7 @@ if [[ -n "$REMOTE_HOST" || -n "$REMOTE_HOST_FILE" || -n "$ANSIBLE_INVENTORY" ]];
   printf "${BOLD}${CYAN}║  CyberAar Fleet Scan — %d host(s)%-27s║${NC}\n" "${#FLEET_HOSTS[@]}" ""
   printf "${BOLD}${CYAN}╚══════════════════════════════════════════════════════════════╝${NC}\n"
 
+  _cyberaar_ssh_ctl_init
   FLEET_OK=0; FLEET_FAIL=0
   for host in "${FLEET_HOSTS[@]}"; do
     # Build output paths for this host

--- a/scripts/src/lib/remote.sh
+++ b/scripts/src/lib/remote.sh
@@ -41,7 +41,49 @@ _build_host_list() {
   printf '%s\n' "${out[@]}"
 }
 
+# Shared directory for the ssh control sockets, private to this run. Removed on
+# exit along with any master connections still persisting, so a scan leaves no
+# open sessions behind on the operator's machine.
+_CYBERAAR_SSH_CTL_DIR=""
+_cyberaar_ssh_ctl_init() {
+  _CYBERAAR_SSH_CTL_DIR="$(mktemp -d -t cyberaar-ssh-XXXXXX 2>/dev/null)" || _CYBERAAR_SSH_CTL_DIR=""
+  [[ -n "$_CYBERAAR_SSH_CTL_DIR" ]] && chmod 700 "$_CYBERAAR_SSH_CTL_DIR" 2>/dev/null || true
+}
+_cyberaar_ssh_ctl_cleanup() {
+  [[ -n "$_CYBERAAR_SSH_CTL_DIR" && -d "$_CYBERAAR_SSH_CTL_DIR" ]] || return 0
+  local sock
+  for sock in "$_CYBERAAR_SSH_CTL_DIR"/*; do
+    [[ -S "$sock" ]] && ssh -o ControlPath="$sock" -O exit placeholder &>/dev/null || true
+  done
+  rm -rf "$_CYBERAAR_SSH_CTL_DIR"
+  _CYBERAAR_SSH_CTL_DIR=""
+}
+trap _cyberaar_ssh_ctl_cleanup EXIT INT TERM
+
 # ── Run scan on a single remote host via SSH ──────────────────────────────────
+#
+# TRANSPORT: ssh with the file on stdin, not scp.
+#
+# scp in OpenSSH 9 and later speaks the SFTP protocol by default, and a hardened
+# host frequently has no sftp subsystem at all: removing it is a normal CIS and
+# STIG hardening step, and this toolkit's own ssh role is the kind of thing that
+# does it. The result was that the remote scan failed on exactly the hosts most
+# likely to be running a security tool, with
+#
+#     scp: Connection closed
+#
+# swallowed by 2>/dev/null, then "bash: /tmp/.cyberaar-baseline-xxx.sh: No such
+# file or directory" from the run that followed, and a cheerful "1 succeeded" at
+# the end. Found on a live bastion, not in review.
+#
+# Piping over an ssh session needs no subsystem, no scp binary and no sftp, so it
+# works wherever an interactive command works. `cat > file` is also the only
+# transport available when a host allows command execution but no file transfer.
+#
+# EVERY STEP IS CHECKED. The previous version returned success unless the initial
+# connectivity probe failed, so a scan that copied nothing, ran nothing and
+# fetched nothing still counted as a success in the fleet summary. A scanner that
+# cannot tell you it failed is worse than one that is simply absent.
 _remote_scan() {
   local host="$1"
   local html_out="$2"
@@ -49,49 +91,129 @@ _remote_scan() {
 
   local ssh_opts=(-o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -o BatchMode=yes)
   [[ -n "$REMOTE_KEY" ]] && ssh_opts+=(-i "$REMOTE_KEY")
+
+  # One TCP connection per host, reused for all seven operations below.
+  #
+  # A scan opens a connection to probe, to push the script, to check it landed,
+  # to run it, to fetch each report and to clean up. Without multiplexing that is
+  # seven full handshakes per host, so a fifty-host fleet performs three hundred
+  # and fifty. That is slow, it pushes against sshd's MaxStartups (10:30:100 by
+  # default, past which it refuses roughly a third of new connections at random),
+  # and on a host running fail2ban it looks like exactly the thing fail2ban is
+  # there to stop.
+  #
+  # Found the hard way: scanning one host repeatedly during development got this
+  # workstation banned by the estate's own fail2ban.
+  #
+  # %C hashes host, port, user and local host into a short filename, which keeps
+  # the socket path under the 104-byte sun_path limit that longer schemes hit.
+  if [[ -n "$_CYBERAAR_SSH_CTL_DIR" ]]; then
+    ssh_opts+=(-o ControlMaster=auto -o "ControlPath=${_CYBERAAR_SSH_CTL_DIR}/%C" -o ControlPersist=30s)
+  fi
+  # Anything the operator passed with --ssh-opt, most usefully -J for a bastion.
+  # Estates that matter put their hosts behind a jump host, and without this the
+  # scanner could only reach machines that were already reachable directly.
+  local _o
+  for _o in ${REMOTE_SSH_OPTS[@]+"${REMOTE_SSH_OPTS[@]}"}; do ssh_opts+=("$_o"); done
+
   local target="${REMOTE_USER}@${host}"
   local _rand
   _rand=$(openssl rand -hex 8 2>/dev/null || tr -dc 'a-f0-9' < /dev/urandom 2>/dev/null | head -c 16)
   local remote_script="/tmp/.cyberaar-baseline-${_rand}.sh"
+  local remote_html="/tmp/.cyberaar-report-${_rand}.html"
+  local remote_json="/tmp/.cyberaar-report-${_rand}.json"
 
   printf "\n${BOLD}${CYAN}━━━  Remote scan: %s  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n" "$host"
 
-  # Test SSH connectivity first
-  if ! ssh "${ssh_opts[@]}" "$target" "echo ok" &>/dev/null; then
+  # ── 1. Reachability ────────────────────────────────────────────────────────
+  local _probe
+  if ! _probe=$(ssh "${ssh_opts[@]}" "$target" "echo ok" 2>&1); then
     printf "  ${RED}❌  SSH connection failed: %s@%s${NC}\n" "$REMOTE_USER" "$host"
-    printf "     Check: host reachable, user exists, key/password auth works.\n"
+    printf "     %s\n" "${_probe%%$'\n'*}"
+    printf "     Check: host reachable, user exists, key auth works without a passphrase.\n"
+    printf "     Behind a bastion? Pass it through: --ssh-opt '-J user@bastion'\n"
     return 1
   fi
 
-  # Copy script to remote
-  scp "${ssh_opts[@]/#-o/-o}" -q "$SCRIPT_PATH" "${target}:${remote_script}" 2>/dev/null
-
-  # Build remote flags
-  local rflags=""
-  [[ -n "$html_out" ]] && rflags="$rflags --html-out /tmp/.cyberaar-report-${_rand}.html"
-  [[ -n "$json_out" ]] && rflags="$rflags --json-out /tmp/.cyberaar-report-${_rand}.json"
-
-  # Execute on remote (always needs root — try sudo if not root user)
-  if [[ "$REMOTE_USER" == "root" ]]; then
-    ssh "${ssh_opts[@]}" "$target" "bash '${remote_script}'${rflags:+ $rflags}" || true
-  else
-    ssh "${ssh_opts[@]}" "$target" "sudo bash '${remote_script}'${rflags:+ $rflags}" || true
+  # ── 2. Push the script ─────────────────────────────────────────────────────
+  local _err
+  if ! _err=$(ssh "${ssh_opts[@]}" "$target" \
+        "cat > '${remote_script}' && chmod 700 '${remote_script}'" < "$SCRIPT_PATH" 2>&1); then
+    printf "  ${RED}❌  Could not copy the audit script to %s${NC}\n" "$host"
+    printf "     %s\n" "${_err%%$'\n'*}"
+    printf "     The remote /tmp may be full, noexec, or read-only.\n"
+    return 1
   fi
 
-  # Retrieve reports
+  # Landed and non-empty. A truncated copy runs and produces nonsense.
+  local _size
+  _size=$(ssh "${ssh_opts[@]}" "$target" "wc -c < '${remote_script}' 2>/dev/null || echo 0" 2>/dev/null | tr -dc '0-9')
+  if [[ -z "$_size" || "$_size" -lt 1000 ]]; then
+    printf "  ${RED}❌  The audit script did not arrive intact on %s (%s bytes)${NC}\n" "$host" "${_size:-0}"
+    ssh "${ssh_opts[@]}" "$target" "rm -f '${remote_script}'" &>/dev/null || true
+    return 1
+  fi
+
+  # ── 3. Run it ──────────────────────────────────────────────────────────────
+  local rflags=""
+  [[ -n "$html_out" ]] && rflags="$rflags --html-out ${remote_html}"
+  [[ -n "$json_out" ]] && rflags="$rflags --json-out ${remote_json}"
+
+  local _rc=0
+  if [[ "$REMOTE_USER" == "root" ]]; then
+    ssh "${ssh_opts[@]}" "$target" "bash '${remote_script}'${rflags:+ $rflags}" || _rc=$?
+  else
+    # -n so the remote sudo cannot silently wait for a password nobody can type.
+    ssh "${ssh_opts[@]}" "$target" "sudo -n bash '${remote_script}'${rflags:+ $rflags}" || _rc=$?
+  fi
+  if [[ "$_rc" -ne 0 ]]; then
+    printf "  ${RED}❌  The audit did not complete on %s (exit %d)${NC}\n" "$host" "$_rc"
+    printf "     If this is a sudo prompt: %s needs passwordless sudo, or scan as root.\n" "$REMOTE_USER"
+    ssh "${ssh_opts[@]}" "$target" "rm -f '${remote_script}' '${remote_html}' '${remote_json}'" &>/dev/null || true
+    return 1
+  fi
+
+  # ── 4. Fetch the reports ───────────────────────────────────────────────────
+  # Same reasoning as the push: cat over ssh needs no sftp. An empty file counts
+  # as a failure, because a zero-byte report reads as a successful scan of a
+  # machine with no findings.
+  #
+  # Read back through sudo when the scan ran through sudo. The audit runs as root
+  # and writes its reports as root, so an unprivileged login cannot read the
+  # files it just asked for. That failed silently on a live host: the audit
+  # completed, printed its findings to the terminal, and then could not retrieve
+  # a single one of them.
+  local _cat="cat"
+  [[ "$REMOTE_USER" != "root" ]] && _cat="sudo -n cat"
+  local fetch_failed=0
   if [[ -n "$html_out" ]]; then
-    scp "${ssh_opts[@]/#-o/-o}" -q "${target}:/tmp/.cyberaar-report-${_rand}.html" "$html_out" 2>/dev/null \
-      && printf "  🌐 HTML fetched → %s\n" "$html_out" \
-      || printf "  ${YELLOW}⚠️   Could not fetch HTML report from %s${NC}\n" "$host"
+    if ssh "${ssh_opts[@]}" "$target" "$_cat '${remote_html}'" > "$html_out" 2>/dev/null && [[ -s "$html_out" ]]; then
+      printf "  🌐 HTML fetched → %s\n" "$html_out"
+    else
+      rm -f "$html_out"
+      printf "  ${YELLOW}⚠️   Could not fetch the HTML report from %s${NC}\n" "$host"
+      fetch_failed=1
+    fi
   fi
   if [[ -n "$json_out" ]]; then
-    scp "${ssh_opts[@]/#-o/-o}" -q "${target}:/tmp/.cyberaar-report-${_rand}.json" "$json_out" 2>/dev/null \
-      && printf "  📄 JSON fetched → %s\n" "$json_out" \
-      || printf "  ${YELLOW}⚠️   Could not fetch JSON report from %s${NC}\n" "$host"
+    if ssh "${ssh_opts[@]}" "$target" "$_cat '${remote_json}'" > "$json_out" 2>/dev/null && [[ -s "$json_out" ]]; then
+      printf "  📄 JSON fetched → %s\n" "$json_out"
+    else
+      rm -f "$json_out"
+      printf "  ${YELLOW}⚠️   Could not fetch the JSON report from %s${NC}\n" "$host"
+      fetch_failed=1
+    fi
   fi
 
-  # Cleanup remote temp files
-  ssh "${ssh_opts[@]}" "$target" "rm -f '${remote_script}' '/tmp/.cyberaar-report-${_rand}.html' '/tmp/.cyberaar-report-${_rand}.json'" &>/dev/null || true
+  # ── 5. Clean up after ourselves ────────────────────────────────────────────
+  # Root-owned reports need root to remove. Leaving an audit of the machine in
+  # world-readable /tmp is not acceptable housekeeping for a security tool.
+  local _rm="rm -f"
+  [[ "$REMOTE_USER" != "root" ]] && _rm="sudo -n rm -f"
+  ssh "${ssh_opts[@]}" "$target" "$_rm '${remote_script}' '${remote_html}' '${remote_json}'" &>/dev/null || true
+
+  [[ "$fetch_failed" -eq 0 ]] || return 1
+  return 0
 }
 
 # ── Fleet scan dispatcher ─────────────────────────────────────────────────────
@@ -110,6 +232,7 @@ if [[ -n "$REMOTE_HOST" || -n "$REMOTE_HOST_FILE" || -n "$ANSIBLE_INVENTORY" ]];
   printf "${BOLD}${CYAN}║  CyberAar Fleet Scan — %d host(s)%-27s║${NC}\n" "${#FLEET_HOSTS[@]}" ""
   printf "${BOLD}${CYAN}╚══════════════════════════════════════════════════════════════╝${NC}\n"
 
+  _cyberaar_ssh_ctl_init
   FLEET_OK=0; FLEET_FAIL=0
   for host in "${FLEET_HOSTS[@]}"; do
     # Build output paths for this host

--- a/scripts/src/main.sh
+++ b/scripts/src/main.sh
@@ -36,6 +36,8 @@ Remote / Fleet options:
   --inventory <file>     Parse an Ansible inventory file for hosts
   --user <user>          SSH user for remote scan (default: root)
   --ssh-key <keyfile>    SSH private key for remote scan
+  --ssh-opt <opt>        Extra ssh option, repeatable. For a bastion:
+                           --ssh-opt '-J admin@bastion.example.com' 
   --ansible-dir <dir>    Path to your Ansible repo (for playbook suggestions)
 
 Install options:
@@ -69,6 +71,10 @@ HELPEOF
 # ─── CLI ARGS ────────────────────────────────────────────────────────────────
 HTML_OUT=""
 JSON_OUT=""
+# Declared before the parse loop: += on an undeclared name is an error under
+# set -u, which would make the flag unusable rather than merely wrong.
+REMOTE_SSH_OPTS=()
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --html-out)       HTML_OUT="$2";        shift 2 ;;
@@ -77,6 +83,10 @@ while [[ $# -gt 0 ]]; do
     --inventory)      ANSIBLE_INVENTORY="$2";shift 2 ;;
     --user)           REMOTE_USER="$2";     shift 2 ;;
     --ssh-key)        REMOTE_KEY="$2";      shift 2 ;;
+    # Repeatable, and word-split on purpose so --ssh-opt '-J host' and
+    # --ssh-opt -J --ssh-opt host both work.
+    # shellcheck disable=SC2206
+    --ssh-opt)        REMOTE_SSH_OPTS+=($2); shift 2 ;;
     --ansible-dir)    ANSIBLE_DIR="$2";     shift 2 ;;
     --json-out)   JSON_OUT="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;

--- a/scripts/tests/test_aartool.sh
+++ b/scripts/tests/test_aartool.sh
@@ -213,6 +213,18 @@ $AARTOOL install --prefix "$_ins_prefix" --uninstall >/dev/null 2>&1
 check    "uninstall removes the link" "$([ -e "$_ins_prefix/bin/aartool" ] && printf yes || printf no)" "no"
 rm -rf "$_ins_prefix" "$(dirname "$_ins_copy")"
 
+# ── inspect forwards every remote flag the baseline documents ────────────────
+# inspect passes a WHITELIST of options through to cyberaar-baseline.sh, so a
+# flag added to the baseline is silently rejected by aartool until someone
+# remembers to widen that list. This asserts the two agree, rather than leaving
+# it to memory.
+for _flag in --host --host-file --inventory --user --ssh-key --ssh-opt; do
+  if grep -q -- "$_flag" ../scripts/src/main.sh 2>/dev/null || grep -q -- "$_flag" ./src/main.sh 2>/dev/null; then
+    check "inspect forwards $_flag" \
+          "$($AARTOOL inspect "$_flag" x --help 2>&1 | grep -c 'Unknown option')" "0"
+  fi
+done
+
 # ── Per-command help ─────────────────────────────────────────────────────────
 check    "inspect help" "$($AARTOOL inspect --help 2>&1)" "Changes nothing"
 check    "plan help"    "$($AARTOOL plan --help 2>&1)"    "--target"


### PR DESCRIPTION
Found by running aartool against a **live production bastion**, not by reading the code.

## 1. It reported success on a scan that produced nothing

```
bash: /tmp/.cyberaar-baseline-142ce.sh: No such file or directory
⚠️  Could not fetch HTML report
⚠️  Could not fetch JSON report
Fleet scan complete: ✅ 1 succeeded   ❌ 0 failed
```

`_remote_scan` returned 0 unless the *initial connectivity probe* failed. Every later step was `2>/dev/null` or `|| true`. **A scanner that cannot tell you it failed is worse than no scanner: you believe you have coverage.**

## 2. scp does not work on a hardened host

OpenSSH 9+ speaks SFTP for scp, and a hardened host frequently has **no sftp subsystem** — removing it is a standard CIS/STIG step. The bastion had no `Subsystem` directive at all, so scp died with `Connection closed` while ssh worked fine.

The remote audit failed on precisely the hosts most likely to be running a security tool — and this toolkit's own ssh role is the sort of thing that causes it.

Transport is now `ssh host "cat > file"` with the script on stdin. No subsystem, no scp, no sftp.

## 3. The reports could not be read back

The audit runs under `sudo` and writes reports as root, mode 600. The fetch ran as the unprivileged user. A scan that completed and printed its findings retrieved none of them. Fetch and cleanup now use sudo when the scan did.

## 4. Seven SSH handshakes per host

Probe, push, verify, run, fetch, fetch, clean. On a 50-host fleet that is 350 connections in a burst — slow, hard against `MaxStartups`, and indistinguishable from what fail2ban exists to stop. **Scanning one host repeatedly during this work got my own workstation banned by the estate's fail2ban**, which is a fair verdict on the design. Now multiplexed with `ControlMaster`.

## Also: `--ssh-opt`, because estates have bastions

The scan could only reach directly-reachable hosts, which excludes most production.

```bash
aartool inspect --host 10.0.1.51 --user admin --ssh-opt '-J admin@bastion'
```

aartool forwards a *whitelist* of flags, so a new baseline flag is silently rejected until someone widens it. There is now a test asserting the two agree.

**Verified live**: 109 checks against stg-hel-mgmt-01, score 72 (79 pass / 26 warn / 4 fail), all twelve KRN checks evaluated, HTML and JSON retrieved, remote temp files removed. 62 tests.