### PR TITLE
fix(html): the score ring lost its glow to a typo, and nothing was linting

### DIFF
--- a/.github/workflows/baseline-build.yml
+++ b/.github/workflows/baseline-build.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "scripts/src/**"
       - "scripts/build.sh"
+      - "scripts/run-hardening.sh"
       - "scripts/cyberaar-baseline.sh"
       - ".github/workflows/baseline-build.yml"
   pull_request:
@@ -14,6 +15,7 @@ on:
     paths:
       - "scripts/src/**"
       - "scripts/build.sh"
+      - "scripts/run-hardening.sh"
       - "scripts/cyberaar-baseline.sh"
       - ".github/workflows/baseline-build.yml"
   workflow_dispatch:
@@ -56,6 +58,16 @@ jobs:
       # tests Rocky 9 and Ubuntu 22.04, so nothing in the pipeline ever executes
       # on openSUSE, Alpine, Arch or Amazon Linux. These feed the mapping their
       # real /etc/os-release and assert the answer.
+      # Neither the baseline nor run-hardening.sh was linted. That is how a typo
+      # split ${RING_COLORALPHA} into ${RING_COLOR}ALPHA and shipped invalid CSS
+      # into every HTML report, silently, because browsers drop a bad filter
+      # without complaining. shellcheck reported it as an unused variable.
+      - name: Shellcheck
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          shellcheck -S warning scripts/cyberaar-baseline.sh
+          shellcheck -S warning scripts/run-hardening.sh
+
       - name: Distribution mapping tests
         run: bash scripts/tests/test_distro.sh
 

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -83,10 +83,12 @@ while [[ $# -gt 0 ]]; do
     --inventory)      ANSIBLE_INVENTORY="$2";shift 2 ;;
     --user)           REMOTE_USER="$2";     shift 2 ;;
     --ssh-key)        REMOTE_KEY="$2";      shift 2 ;;
-    # Repeatable, and word-split on purpose so --ssh-opt '-J host' and
-    # --ssh-opt -J --ssh-opt host both work.
-    # shellcheck disable=SC2206
-    --ssh-opt)        REMOTE_SSH_OPTS+=($2); shift 2 ;;
+    # Repeatable, and split explicitly so --ssh-opt '-J host' and
+    # --ssh-opt -J --ssh-opt host behave the same. read -ra rather than bare
+    # word splitting: it says what it means and needs no shellcheck directive,
+    # which cannot legally sit in front of a single case branch anyway.
+    --ssh-opt)        read -ra _ssh_opt_words <<< "$2"
+                      REMOTE_SSH_OPTS+=("${_ssh_opt_words[@]}"); shift 2 ;;
     --ansible-dir)    ANSIBLE_DIR="$2";     shift 2 ;;
     --json-out)   JSON_OUT="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
@@ -119,7 +121,7 @@ fi
 # ─── INSTALL ─────────────────────────────────────────────────────────────────
 if [[ "$DO_INSTALL" == true ]]; then
   [[ $EUID -ne 0 ]] && { echo '❌  Root required: sudo bash cyberaar-baseline.sh --install'; exit 1; }
-  INST_DEST='/usr/local/bin/cyberaar-baseline'
+  INST_DEST="/usr/local/bin/${SCRIPT_NAME}"
   cp -f "$SCRIPT_PATH" "$INST_DEST"
   chmod 755 "$INST_DEST"
   chown root:root "$INST_DEST"
@@ -130,7 +132,7 @@ fi
 
 # ─── UNINSTALL ───────────────────────────────────────────────────────────────
 if [[ "$DO_UNINSTALL" == true ]]; then
-  INST_DEST='/usr/local/bin/cyberaar-baseline'
+  INST_DEST="/usr/local/bin/${SCRIPT_NAME}"
   [[ -f "$INST_DEST" ]] && rm -f "$INST_DEST" && echo "✅  Removed $INST_DEST" || echo "⚠️   Not found: $INST_DEST"
   exit 0
 fi
@@ -167,6 +169,9 @@ fi
 OS_RELEASE_PATH="${OS_RELEASE_PATH:-/etc/os-release}"
 
 _DISTRO_ID=""; _DISTRO_LIKE=""; _DISTRO_PRETTY=""; _DISTRO_VERSION=""
+# The path is deliberately a variable so tests can point at a fixture and a
+# mounted image can be identified; shellcheck cannot follow that statically.
+# shellcheck source=/dev/null
 if [[ -r "$OS_RELEASE_PATH" ]]; then
   _DISTRO_ID="$(       . "$OS_RELEASE_PATH" 2>/dev/null; printf '%s' "${ID:-}" )"
   _DISTRO_LIKE="$(     . "$OS_RELEASE_PATH" 2>/dev/null; printf '%s' "${ID_LIKE:-}" )"
@@ -2290,7 +2295,6 @@ _render_html() {
 
   # Build Ansible remediation HTML
   ANSIBLE_PLAN_HTML=""
-  declare -A seen_html_tags=()
   declare -A html_plan_entries=()
   for _id in "${FAIL_IDS[@]}" "${WARN_IDS[@]}"; do
     [[ -z "${ANSIBLE_MAP[$_id]+x}" ]] && continue
@@ -2496,7 +2500,7 @@ header {
 .score-ring .bar   { fill: none; stroke-width: 7; stroke-linecap: round;
                      stroke-dasharray: 226; stroke-dashoffset: ${RING_OFFSET};
                      stroke: ${RING_COLOR};
-                     filter: drop-shadow(0 0 6px ${RING_COLOR}ALPHA); }
+                     filter: drop-shadow(0 0 6px ${RING_COLORALPHA}); }
 .score-ring-label {
   position: absolute;
   inset: 0;

--- a/scripts/src/lib/distro.sh
+++ b/scripts/src/lib/distro.sh
@@ -29,6 +29,9 @@
 OS_RELEASE_PATH="${OS_RELEASE_PATH:-/etc/os-release}"
 
 _DISTRO_ID=""; _DISTRO_LIKE=""; _DISTRO_PRETTY=""; _DISTRO_VERSION=""
+# The path is deliberately a variable so tests can point at a fixture and a
+# mounted image can be identified; shellcheck cannot follow that statically.
+# shellcheck source=/dev/null
 if [[ -r "$OS_RELEASE_PATH" ]]; then
   _DISTRO_ID="$(       . "$OS_RELEASE_PATH" 2>/dev/null; printf '%s' "${ID:-}" )"
   _DISTRO_LIKE="$(     . "$OS_RELEASE_PATH" 2>/dev/null; printf '%s' "${ID_LIKE:-}" )"

--- a/scripts/src/main.sh
+++ b/scripts/src/main.sh
@@ -83,10 +83,12 @@ while [[ $# -gt 0 ]]; do
     --inventory)      ANSIBLE_INVENTORY="$2";shift 2 ;;
     --user)           REMOTE_USER="$2";     shift 2 ;;
     --ssh-key)        REMOTE_KEY="$2";      shift 2 ;;
-    # Repeatable, and word-split on purpose so --ssh-opt '-J host' and
-    # --ssh-opt -J --ssh-opt host both work.
-    # shellcheck disable=SC2206
-    --ssh-opt)        REMOTE_SSH_OPTS+=($2); shift 2 ;;
+    # Repeatable, and split explicitly so --ssh-opt '-J host' and
+    # --ssh-opt -J --ssh-opt host behave the same. read -ra rather than bare
+    # word splitting: it says what it means and needs no shellcheck directive,
+    # which cannot legally sit in front of a single case branch anyway.
+    --ssh-opt)        read -ra _ssh_opt_words <<< "$2"
+                      REMOTE_SSH_OPTS+=("${_ssh_opt_words[@]}"); shift 2 ;;
     --ansible-dir)    ANSIBLE_DIR="$2";     shift 2 ;;
     --json-out)   JSON_OUT="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
@@ -119,7 +121,7 @@ fi
 # ─── INSTALL ─────────────────────────────────────────────────────────────────
 if [[ "$DO_INSTALL" == true ]]; then
   [[ $EUID -ne 0 ]] && { echo '❌  Root required: sudo bash cyberaar-baseline.sh --install'; exit 1; }
-  INST_DEST='/usr/local/bin/cyberaar-baseline'
+  INST_DEST="/usr/local/bin/${SCRIPT_NAME}"
   cp -f "$SCRIPT_PATH" "$INST_DEST"
   chmod 755 "$INST_DEST"
   chown root:root "$INST_DEST"
@@ -130,7 +132,7 @@ fi
 
 # ─── UNINSTALL ───────────────────────────────────────────────────────────────
 if [[ "$DO_UNINSTALL" == true ]]; then
-  INST_DEST='/usr/local/bin/cyberaar-baseline'
+  INST_DEST="/usr/local/bin/${SCRIPT_NAME}"
   [[ -f "$INST_DEST" ]] && rm -f "$INST_DEST" && echo "✅  Removed $INST_DEST" || echo "⚠️   Not found: $INST_DEST"
   exit 0
 fi

--- a/scripts/src/renderers/html.sh
+++ b/scripts/src/renderers/html.sh
@@ -61,7 +61,6 @@ _render_html() {
 
   # Build Ansible remediation HTML
   ANSIBLE_PLAN_HTML=""
-  declare -A seen_html_tags=()
   declare -A html_plan_entries=()
   for _id in "${FAIL_IDS[@]}" "${WARN_IDS[@]}"; do
     [[ -z "${ANSIBLE_MAP[$_id]+x}" ]] && continue
@@ -267,7 +266,7 @@ header {
 .score-ring .bar   { fill: none; stroke-width: 7; stroke-linecap: round;
                      stroke-dasharray: 226; stroke-dashoffset: ${RING_OFFSET};
                      stroke: ${RING_COLOR};
-                     filter: drop-shadow(0 0 6px ${RING_COLOR}ALPHA); }
+                     filter: drop-shadow(0 0 6px ${RING_COLORALPHA}); }
 .score-ring-label {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
Neither `cyberaar-baseline.sh` nor `run-hardening.sh` was ever passed through shellcheck. Wiring it in found a defect that had been shipping in **every HTML report**.

```css
filter: drop-shadow(0 0 6px ${RING_COLOR}ALPHA);
```

The variable is `RING_COLORALPHA`. The typo splits the name, so the expansion yields the ring colour followed by the literal text `ALPHA`:

```css
drop-shadow(0 0 6px #f59e0bALPHA)
```

Invalid, so browsers drop the declaration and the score ring renders with no glow. Nothing failed, nothing warned, and the value was computed correctly four lines earlier then never used. **Confirmed in a report generated from a live host**, not just in the source.

shellcheck reported it as `SC2034: RING_COLORALPHA appears unused`. That is what an unused variable usually means — not dead weight, but something meant to be read that isn't.

## Two more from the same pass

`seen_html_tags` was declared and never read, the loop beneath doing that job with `html_plan_entries`. `SCRIPT_NAME` was set and never read while install and uninstall each hardcoded the same string; it is now the single place the name is written.

## One I introduced

My `--ssh-opt` change carried a shellcheck directive in front of a single `case` branch, where directives are not valid, and it became a parse error the moment anything looked. The word split is now explicit with `read -ra`.

CI now runs shellcheck over both scripts on every change to either. Both clean at `-S warning`.