### PR TITLE
feat(roles): make the kernel attack surface remediable, and check the advice works

### DIFF
--- a/.github/workflows/baseline-build.yml
+++ b/.github/workflows/baseline-build.yml
@@ -8,6 +8,8 @@ on:
       - "scripts/src/**"
       - "scripts/build.sh"
       - "scripts/run-hardening.sh"
+      - "ansible-hardening/playbooks/**"
+      - "ansible-hardening/roles/*/defaults/**"
       - "scripts/cyberaar-baseline.sh"
       - ".github/workflows/baseline-build.yml"
   pull_request:
@@ -16,6 +18,8 @@ on:
       - "scripts/src/**"
       - "scripts/build.sh"
       - "scripts/run-hardening.sh"
+      - "ansible-hardening/playbooks/**"
+      - "ansible-hardening/roles/*/defaults/**"
       - "scripts/cyberaar-baseline.sh"
       - ".github/workflows/baseline-build.yml"
   workflow_dispatch:
@@ -70,6 +74,13 @@ jobs:
 
       - name: Distribution mapping tests
         run: bash scripts/tests/test_distro.sh
+
+      # The plan printed at the end of every audit is built from ANSIBLE_MAP.
+      # Nothing verified those tags and roles existed, so a typo produced a
+      # command that runs cleanly, matches nothing and changes nothing, while
+      # the operator believes the finding is remediated.
+      - name: Remediation map points at real tags and roles
+        run: bash scripts/tests/test_remediation_map.sh
 
       - name: Escaping regression tests
         run: bash scripts/tests/test_escaping.sh

--- a/ansible-hardening/roles/linux_kernel_hardening_rhel9/defaults/main.yml
+++ b/ansible-hardening/roles/linux_kernel_hardening_rhel9/defaults/main.yml
@@ -30,3 +30,34 @@ linux_kernel_modprobe_file: "/etc/modprobe.d/99-cis-modprobe-blacklist.conf"
 
 # Whether to attempt unloading modules if loaded (requires reboot for full effect anyway)
 linux_kernel_unload_blacklisted: false
+
+# ── Attack surface reduction (KRN-01..KRN-12) ────────────────────────────────
+# These do not fix bugs. They remove the doorways that whole classes of local
+# privilege escalation walk through, which is what protects a machine in the
+# window before a patch exists, and on the machine that cannot be rebooted.
+#
+# The defaults mirror the two tiers in 'aartool surface':
+#
+#   true by default   no mainstream workload is known to depend on it
+#   false by default  it will break something real for somebody; the comment
+#                     says what, and you opt in deliberately
+#
+# Defaulting the disruptive ones to false is not timidity. A role that silently
+# breaks rootless containers gets disabled wholesale, and then none of the
+# safe settings apply either.
+
+# Safe tier — on by default.
+linux_kernel_disable_unprivileged_bpf: true    # KRN-02 eBPF verifier exploits
+linux_kernel_disable_userfaultfd: true         # KRN-04 turns races into reliable exploits
+linux_kernel_disable_kexec: true               # KRN-06 boots a kernel around Secure Boot
+linux_kernel_disable_ldisc_autoload: true      # KRN-07 old, lightly audited TTY modules
+linux_kernel_bpf_jit_harden: true              # KRN-09 JIT spraying into kernel memory
+linux_kernel_restrict_sysrq: true              # KRN-10 console memory dump
+
+# Strict tier — off by default, each with the reason.
+# Breaks rootless Docker and Podman, Chrome's sandbox, and most CI runners.
+linux_kernel_restrict_userns: false            # KRN-01
+# Breaks workloads that use it: some databases, proxies, async runtimes.
+linux_kernel_restrict_io_uring: false          # KRN-03
+# Irreversible until reboot: blocks every later modprobe, including yours.
+linux_kernel_lock_modules: false               # KRN-05

--- a/ansible-hardening/roles/linux_kernel_hardening_rhel9/templates/99-cis-kernel-hardening.conf.j2
+++ b/ansible-hardening/roles/linux_kernel_hardening_rhel9/templates/99-cis-kernel-hardening.conf.j2
@@ -58,3 +58,49 @@ net.ipv6.conf.default.accept_ra = 0
 
 # Additional defense-in-depth (L2)
 kernel.kptr_restrict = 2
+
+# ── Attack surface reduction (KRN-01..KRN-12) ────────────────────────────────
+# Each of these closes a class of local privilege escalation rather than a
+# single CVE, and takes effect without a reboot.
+{% if linux_kernel_disable_unprivileged_bpf | bool %}
+# KRN-02  Unprivileged eBPF: a recurring source of kernel exploits
+kernel.unprivileged_bpf_disabled = 1
+{% endif %}
+{% if linux_kernel_disable_userfaultfd | bool %}
+# KRN-04  userfaultfd: used to make kernel race conditions reliably exploitable
+vm.unprivileged_userfaultfd = 0
+{% endif %}
+{% if linux_kernel_disable_kexec | bool %}
+# KRN-06  kexec: boots an arbitrary kernel without firmware, bypassing Secure Boot
+kernel.kexec_load_disabled = 1
+{% endif %}
+{% if linux_kernel_disable_ldisc_autoload | bool %}
+# KRN-07  TTY line discipline autoload: old, lightly audited modules
+dev.tty.ldisc_autoload = 0
+{% endif %}
+{% if linux_kernel_bpf_jit_harden | bool %}
+# KRN-09  BPF JIT hardening: makes JIT spraying harder
+net.core.bpf_jit_harden = 2
+{% endif %}
+{% if linux_kernel_restrict_sysrq | bool %}
+# KRN-10  SysRq: 4 keeps the keyboard reset combination and drops the rest
+kernel.sysrq = 4
+{% endif %}
+{% if linux_kernel_restrict_userns | bool %}
+# KRN-01  Unprivileged user namespaces: the doorway most published Linux LPEs use.
+#         Breaks rootless containers and Chrome's sandbox. Opt-in.
+{% if ansible_os_family == 'Debian' %}
+kernel.unprivileged_userns_clone = 0
+{% else %}
+user.max_user_namespaces = 0
+{% endif %}
+{% endif %}
+{% if linux_kernel_restrict_io_uring | bool %}
+# KRN-03  io_uring: young, large, over-represented in recent LPEs. Opt-in.
+kernel.io_uring_disabled = 2
+{% endif %}
+{% if linux_kernel_lock_modules | bool %}
+# KRN-05  Module loading lockdown. IRREVERSIBLE until reboot, and it blocks
+#         every later modprobe including your own. Opt-in, and read that twice.
+kernel.modules_disabled = 1
+{% endif %}

--- a/ansible-hardening/roles/linux_kernel_hardening_ubuntu/defaults/main.yml
+++ b/ansible-hardening/roles/linux_kernel_hardening_ubuntu/defaults/main.yml
@@ -28,3 +28,34 @@ linux_kernel_unload_blacklisted: false
 
 # Role disable var
 linux_kernel_hardening_disabled: false
+
+# ── Attack surface reduction (KRN-01..KRN-12) ────────────────────────────────
+# These do not fix bugs. They remove the doorways that whole classes of local
+# privilege escalation walk through, which is what protects a machine in the
+# window before a patch exists, and on the machine that cannot be rebooted.
+#
+# The defaults mirror the two tiers in 'aartool surface':
+#
+#   true by default   no mainstream workload is known to depend on it
+#   false by default  it will break something real for somebody; the comment
+#                     says what, and you opt in deliberately
+#
+# Defaulting the disruptive ones to false is not timidity. A role that silently
+# breaks rootless containers gets disabled wholesale, and then none of the
+# safe settings apply either.
+
+# Safe tier — on by default.
+linux_kernel_disable_unprivileged_bpf: true    # KRN-02 eBPF verifier exploits
+linux_kernel_disable_userfaultfd: true         # KRN-04 turns races into reliable exploits
+linux_kernel_disable_kexec: true               # KRN-06 boots a kernel around Secure Boot
+linux_kernel_disable_ldisc_autoload: true      # KRN-07 old, lightly audited TTY modules
+linux_kernel_bpf_jit_harden: true              # KRN-09 JIT spraying into kernel memory
+linux_kernel_restrict_sysrq: true              # KRN-10 console memory dump
+
+# Strict tier — off by default, each with the reason.
+# Breaks rootless Docker and Podman, Chrome's sandbox, and most CI runners.
+linux_kernel_restrict_userns: false            # KRN-01
+# Breaks workloads that use it: some databases, proxies, async runtimes.
+linux_kernel_restrict_io_uring: false          # KRN-03
+# Irreversible until reboot: blocks every later modprobe, including yours.
+linux_kernel_lock_modules: false               # KRN-05

--- a/ansible-hardening/roles/linux_kernel_hardening_ubuntu/templates/99-cis-kernel-hardening.conf.j2
+++ b/ansible-hardening/roles/linux_kernel_hardening_ubuntu/templates/99-cis-kernel-hardening.conf.j2
@@ -62,3 +62,49 @@ net.ipv6.conf.default.accept_ra = 0
 
 # Additional defense-in-depth (L2)
 kernel.kptr_restrict = 2
+
+# ── Attack surface reduction (KRN-01..KRN-12) ────────────────────────────────
+# Each of these closes a class of local privilege escalation rather than a
+# single CVE, and takes effect without a reboot.
+{% if linux_kernel_disable_unprivileged_bpf | bool %}
+# KRN-02  Unprivileged eBPF: a recurring source of kernel exploits
+kernel.unprivileged_bpf_disabled = 1
+{% endif %}
+{% if linux_kernel_disable_userfaultfd | bool %}
+# KRN-04  userfaultfd: used to make kernel race conditions reliably exploitable
+vm.unprivileged_userfaultfd = 0
+{% endif %}
+{% if linux_kernel_disable_kexec | bool %}
+# KRN-06  kexec: boots an arbitrary kernel without firmware, bypassing Secure Boot
+kernel.kexec_load_disabled = 1
+{% endif %}
+{% if linux_kernel_disable_ldisc_autoload | bool %}
+# KRN-07  TTY line discipline autoload: old, lightly audited modules
+dev.tty.ldisc_autoload = 0
+{% endif %}
+{% if linux_kernel_bpf_jit_harden | bool %}
+# KRN-09  BPF JIT hardening: makes JIT spraying harder
+net.core.bpf_jit_harden = 2
+{% endif %}
+{% if linux_kernel_restrict_sysrq | bool %}
+# KRN-10  SysRq: 4 keeps the keyboard reset combination and drops the rest
+kernel.sysrq = 4
+{% endif %}
+{% if linux_kernel_restrict_userns | bool %}
+# KRN-01  Unprivileged user namespaces: the doorway most published Linux LPEs use.
+#         Breaks rootless containers and Chrome's sandbox. Opt-in.
+{% if ansible_os_family == 'Debian' %}
+kernel.unprivileged_userns_clone = 0
+{% else %}
+user.max_user_namespaces = 0
+{% endif %}
+{% endif %}
+{% if linux_kernel_restrict_io_uring | bool %}
+# KRN-03  io_uring: young, large, over-represented in recent LPEs. Opt-in.
+kernel.io_uring_disabled = 2
+{% endif %}
+{% if linux_kernel_lock_modules | bool %}
+# KRN-05  Module loading lockdown. IRREVERSIBLE until reboot, and it blocks
+#         every later modprobe including your own. Opt-in, and read that twice.
+kernel.modules_disabled = 1
+{% endif %}

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -347,6 +347,28 @@ declare -A ANSIBLE_MAP=(
   ["COMP-10"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|USB storage module blacklist"
   ["COMP-11"]="cron|linux_cron_hardening_rhel9|linux_cron_hardening_ubuntu|Cron service enabled"
   ["COMP-12"]="cron|linux_cron_hardening_rhel9|linux_cron_hardening_ubuntu|cron/at allow-list enforcement"
+
+  # ── Kernel attack surface (KRN-01..KRN-12) ─────────────────────────────────
+  # All served by the same role and the same tag, because they are all sysctls
+  # in one drop-in file. Without these entries a KRN warning appeared in the
+  # report with no way into the remediation plan: the renderer skips any id it
+  # cannot map, silently.
+  #
+  # The role applies the safe tier by default. KRN-01, KRN-03 and KRN-05 break
+  # real workloads, so their toggles default to false and the operator opts in
+  # deliberately; the description says so rather than leaving them to find out.
+  ["KRN-01"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Unprivileged user namespaces (opt-in: linux_kernel_restrict_userns=true, breaks rootless containers)"
+  ["KRN-02"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Unprivileged eBPF disabled"
+  ["KRN-03"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|io_uring restricted (opt-in: linux_kernel_restrict_io_uring=true)"
+  ["KRN-04"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Unprivileged userfaultfd disabled"
+  ["KRN-05"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Module loading lockdown (opt-in: linux_kernel_lock_modules=true, irreversible until reboot)"
+  ["KRN-06"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|kexec disabled"
+  ["KRN-07"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|TTY line discipline autoload disabled"
+  # KRN-08 lockdown is a boot parameter or Secure Boot, not a sysctl. No role.
+  ["KRN-09"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|BPF JIT hardening"
+  ["KRN-10"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|SysRq restricted"
+  ["KRN-11"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Exotic filesystem modules blacklisted"
+  # KRN-12 is the summary of the four above it, not a setting of its own.
 )
 
 # =============================================================================

--- a/scripts/src/lib/ansible_map.sh
+++ b/scripts/src/lib/ansible_map.sh
@@ -108,4 +108,26 @@ declare -A ANSIBLE_MAP=(
   ["COMP-10"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|USB storage module blacklist"
   ["COMP-11"]="cron|linux_cron_hardening_rhel9|linux_cron_hardening_ubuntu|Cron service enabled"
   ["COMP-12"]="cron|linux_cron_hardening_rhel9|linux_cron_hardening_ubuntu|cron/at allow-list enforcement"
+
+  # ── Kernel attack surface (KRN-01..KRN-12) ─────────────────────────────────
+  # All served by the same role and the same tag, because they are all sysctls
+  # in one drop-in file. Without these entries a KRN warning appeared in the
+  # report with no way into the remediation plan: the renderer skips any id it
+  # cannot map, silently.
+  #
+  # The role applies the safe tier by default. KRN-01, KRN-03 and KRN-05 break
+  # real workloads, so their toggles default to false and the operator opts in
+  # deliberately; the description says so rather than leaving them to find out.
+  ["KRN-01"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Unprivileged user namespaces (opt-in: linux_kernel_restrict_userns=true, breaks rootless containers)"
+  ["KRN-02"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Unprivileged eBPF disabled"
+  ["KRN-03"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|io_uring restricted (opt-in: linux_kernel_restrict_io_uring=true)"
+  ["KRN-04"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Unprivileged userfaultfd disabled"
+  ["KRN-05"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Module loading lockdown (opt-in: linux_kernel_lock_modules=true, irreversible until reboot)"
+  ["KRN-06"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|kexec disabled"
+  ["KRN-07"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|TTY line discipline autoload disabled"
+  # KRN-08 lockdown is a boot parameter or Secure Boot, not a sysctl. No role.
+  ["KRN-09"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|BPF JIT hardening"
+  ["KRN-10"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|SysRq restricted"
+  ["KRN-11"]="kernel,sysctl|linux_kernel_hardening_rhel9|linux_kernel_hardening_ubuntu|Exotic filesystem modules blacklisted"
+  # KRN-12 is the summary of the four above it, not a setting of its own.
 )

--- a/scripts/tests/test_remediation_map.sh
+++ b/scripts/tests/test_remediation_map.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# The remediation advice the report prints must actually work.
+#
+# Every audit ends with a plan like
+#
+#     ansible-playbook -i inventory/hosts playbooks/2_configure_hardening.yml --tags ssh
+#
+# built from ANSIBLE_MAP. Nothing checked that those tags exist in the playbook
+# or that the roles named are real, so a typo produced a command that runs
+# cleanly, matches nothing, changes nothing and reports success. An operator
+# following it would believe the finding was remediated.
+#
+# This is the same shape as the inventory/hosts.yml bug: the tool's own output
+# telling people to run something that cannot work.
+#
+# Run: bash scripts/tests/test_remediation_map.sh
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+MAP="src/lib/ansible_map.sh"
+PLAYBOOK="../ansible-hardening/playbooks/2_configure_hardening.yml"
+ROLES_DIR="../ansible-hardening/roles"
+
+PASS=0 FAIL=0
+fail() { FAIL=$((FAIL + 1)); printf 'FAIL  %s\n' "$1"; }
+
+[[ -f "$MAP" ]]      || { echo "cannot find $MAP"; exit 1; }
+[[ -f "$PLAYBOOK" ]] || { echo "cannot find $PLAYBOOK"; exit 1; }
+
+# Tags the playbook actually defines.
+playbook_tags="$(grep -oE '^\s+tags: \[[^]]+\]' "$PLAYBOOK" \
+  | sed 's/.*\[//; s/\]//' | tr ',' '\n' | tr -d ' ' | sort -u)"
+
+# Roles that actually exist on disk.
+existing_roles="$(find "$ROLES_DIR" -maxdepth 1 -mindepth 1 -type d -printf '%f\n' 2>/dev/null | sort -u)"
+
+while IFS= read -r line; do
+  id="$(printf '%s' "$line" | sed -n 's/.*\["\([A-Z]*-[0-9]*\)"\].*/\1/p')"
+  entry="$(printf '%s' "$line" | sed -n 's/.*\]="\([^"]*\)".*/\1/p')"
+  [[ -n "$id" && -n "$entry" ]] || continue
+
+  IFS='|' read -r tags role_r role_u _desc <<< "$entry"
+
+  # Every tag must exist in the playbook, or the printed command matches nothing.
+  IFS=',' read -ra tag_list <<< "$tags"
+  for t in "${tag_list[@]}"; do
+    [[ -z "$t" ]] && continue
+    if printf '%s\n' "$playbook_tags" | grep -qx "$t"; then
+      PASS=$((PASS + 1))
+    else
+      fail "$id names tag '$t', which no role in the playbook carries"
+    fi
+  done
+
+  # Every role named must exist, or the plan points at nothing.
+  for r in "$role_r" "$role_u"; do
+    [[ -z "$r" || "$r" == "-" ]] && continue
+    if printf '%s\n' "$existing_roles" | grep -qx "$r"; then
+      PASS=$((PASS + 1))
+    else
+      fail "$id names role '$r', which does not exist in roles/"
+    fi
+  done
+done < <(grep -E '^\s*\["[A-Z]+-[0-9]+"\]=' "$MAP")
+
+printf '\n%d assertions passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Two gaps found auditing what I had already shipped.

## The KRN family had no remediation path

Adding twelve checks without `ANSIBLE_MAP` entries meant the report warned about each and then **skipped it in the plan** — the renderer drops any id it cannot map, silently. An operator saw the finding and was offered nothing.

Rather than a parallel role, the existing `linux_kernel_hardening_rhel9`/`_ubuntu` roles are extended. They already own the sysctl drop-in; a second role writing sysctls would eventually fight this one over the same keys.

Nine toggles, defaulting to the same two tiers `aartool surface` uses:

| default | settings |
|---|---|
| **on** | unprivileged_bpf, userfaultfd, kexec, ldisc_autoload, bpf_jit_harden, sysrq |
| **off** | userns, io_uring, modules_disabled |

The disruptive three default to false with the reason beside them. **That is not timidity** — a role that silently breaks rootless containers gets disabled wholesale, and then none of the safe settings apply either.

## The advice was never checked against reality

Every audit ends with a generated command built from `ANSIBLE_MAP`. Nothing verified those tags exist in the playbook or that the roles named are real. **A wrong tag produces a command that runs cleanly, matches nothing, changes nothing and exits zero** — and the operator believes the finding is remediated. Same shape as the `inventory/hosts.yml` bug: our own output telling people to run something that cannot work.

`test_remediation_map.sh` asserts every tag is carried by a role in the playbook and every role named exists on disk. **375 assertions.**

It earned itself on the first run by catching two of my own entries: a `surface` tag I invented that no role carries, and `modules` on KRN-11. Both would have printed remediation that silently did nothing. I then verified the guard fails when a bad tag is reintroduced.

99 of 109 checks are now mapped; the ten that are not are informational or have no configuration fix.