### PR TITLE
fix(advise): the re-audit step told you to audit the wrong machine

### DIFF
--- a/scripts/aartool
+++ b/scripts/aartool
@@ -2219,8 +2219,10 @@ cmd_advise() {
   cat <<EOF
    1. Run the wave 1 preview and read the diff. Nothing is changed by a plan.
    2. Apply wave 1 to ONE host, keeping a second SSH session open the whole time.
-   3. Re-audit that host and compare, so you know what actually moved:
-        sudo aartool inspect -o ./reports
+   3. Re-audit ${tgt} and compare, so you know what actually moved. Audit it
+      the same way you did the first time: this plan was built from a report of
+      ${host:-that host}, and 'sudo aartool inspect' would audit the machine you
+      are standing on instead.
         aartool diff $report ./reports/<the new one>.json
    4. Only then roll the wave to a group, and start again at wave 2.
 

--- a/scripts/aartool-src/cmd/advise.sh
+++ b/scripts/aartool-src/cmd/advise.sh
@@ -236,8 +236,10 @@ cmd_advise() {
   cat <<EOF
    1. Run the wave 1 preview and read the diff. Nothing is changed by a plan.
    2. Apply wave 1 to ONE host, keeping a second SSH session open the whole time.
-   3. Re-audit that host and compare, so you know what actually moved:
-        sudo aartool inspect -o ./reports
+   3. Re-audit ${tgt} and compare, so you know what actually moved. Audit it
+      the same way you did the first time: this plan was built from a report of
+      ${host:-that host}, and 'sudo aartool inspect' would audit the machine you
+      are standing on instead.
         aartool diff $report ./reports/<the new one>.json
    4. Only then roll the wave to a group, and start again at wave 2.
 


### PR DESCRIPTION
Step 3 of the order of operations said:

```
sudo aartool inspect -o ./reports
```

That is right only when the report came from the machine you are standing on. Run it against a plan built from a **remote** host and you audit your own workstation, produce a report for a different host, and `aartool diff` then correctly refuses the comparison as two different machines.

Caught while working through the plan for a real estate node (`stg-hel-siem-01`, audited through a bastion).

It now names the host the plan was built from and says to audit it the same way it was audited the first time. The `-o` goes with it: reports land in `./reports` by default now.