### PR TITLE
fix: cyberaar-baseline --version reported a version three releases stale

### DIFF
--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -3,7 +3,7 @@
 #  CyberAar Security Baseline Checker
 #  Vérificateur de Sécurité de Base CyberAar
 #
-#  Version   : 4.2.0
+#  Version   : see SCRIPT_VERSION below, which is the only place it is written
 #  Author    : CyberAar (https://github.com/cyberaar/aartool)
 #  License   : GPL v3
 #  Target    : RHEL/CentOS/Ubuntu/Debian (Linux Government Servers)
@@ -21,8 +21,8 @@ SCRIPT_VERSION="4.3.0"
 SCRIPT_NAME="cyberaar-baseline"
 
 _show_help() {
-  cat <<'HELPEOF'
-CyberAar Security Baseline Checker v4.2.0
+  cat <<HELPEOF
+CyberAar Security Baseline Checker v${SCRIPT_VERSION}
 
 Usage: cyberaar-baseline [OPTIONS]
 
@@ -99,7 +99,7 @@ while [[ $# -gt 0 ]]; do
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --install)    DO_INSTALL=true; shift ;;
     --uninstall)  DO_UNINSTALL=true; shift ;;
-    --version)    echo "cyberaar-baseline v4.2.0"; exit 0 ;;
+    --version)    echo "cyberaar-baseline v${SCRIPT_VERSION}"; exit 0 ;;
     --help|-h)    _show_help; exit 0 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac

--- a/scripts/src/main.sh
+++ b/scripts/src/main.sh
@@ -3,7 +3,7 @@
 #  CyberAar Security Baseline Checker
 #  Vérificateur de Sécurité de Base CyberAar
 #
-#  Version   : 4.2.0
+#  Version   : see SCRIPT_VERSION below, which is the only place it is written
 #  Author    : CyberAar (https://github.com/cyberaar/aartool)
 #  License   : GPL v3
 #  Target    : RHEL/CentOS/Ubuntu/Debian (Linux Government Servers)
@@ -21,8 +21,8 @@ SCRIPT_VERSION="4.3.0"
 SCRIPT_NAME="cyberaar-baseline"
 
 _show_help() {
-  cat <<'HELPEOF'
-CyberAar Security Baseline Checker v4.2.0
+  cat <<HELPEOF
+CyberAar Security Baseline Checker v${SCRIPT_VERSION}
 
 Usage: cyberaar-baseline [OPTIONS]
 
@@ -99,7 +99,7 @@ while [[ $# -gt 0 ]]; do
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --install)    DO_INSTALL=true; shift ;;
     --uninstall)  DO_UNINSTALL=true; shift ;;
-    --version)    echo "cyberaar-baseline v4.2.0"; exit 0 ;;
+    --version)    echo "cyberaar-baseline v${SCRIPT_VERSION}"; exit 0 ;;
     --help|-h)    _show_help; exit 0 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac

--- a/scripts/tests/test_versions.sh
+++ b/scripts/tests/test_versions.sh
@@ -75,5 +75,41 @@ else
   bad "CHANGELOG.md has no '## [${COLLECTION}]' entry for the version in galaxy.yml"
 fi
 
+# ── No version written down twice ────────────────────────────────────────────
+# The JSON renderer was the obvious case and the one this file was written for.
+# It was not the only one: src/main.sh carried 4.2.0 in a header comment, in the
+# --help banner (inside a quoted heredoc, which is precisely why it could not
+# drift back), and in the output of `--version` itself. So the canonical way of
+# asking the tool its version returned a number three releases stale, on a
+# release where the whole point was getting the numbers right.
+#
+# One place per version. Anything that looks like a semver outside the single
+# assignment line has to justify itself, and the only legitimate matches so far
+# are example IP addresses, which are excluded by requiring a v-prefix or a
+# quote/space boundary rather than a digit-dot run inside an address.
+for f in src/main.sh aartool-src/main.sh; do
+  strays=$(grep -nP '(?<![0-9.])v?[0-9]+\.[0-9]+\.[0-9]+(?![0-9.])' "$f" \
+           | grep -vP '^\s*[0-9]+:(SCRIPT|AARTOOL)_VERSION=' \
+           | grep -vP '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' \
+           | grep -vP '(--host|--ansible-dir|/tmp/report-|10\.0\.)' || true)
+  if [[ -z "$strays" ]]; then
+    ok
+  else
+    bad "$f writes a version literal outside its VERSION assignment:"
+    printf '%s\n' "$strays" | sed 's/^/        /'
+  fi
+done
+
+# `--version` must report the declared version, not a string that happens to
+# look like one. Run the built bundles and compare.
+got=$(bash cyberaar-baseline.sh --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+eq "cyberaar-baseline.sh --version output" "$got" "$BASELINE_SRC"
+got=$(bash aartool --version 2>/dev/null | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+eq "aartool --version output" "$got" "$AARTOOL_SRC"
+
+# The --help banner too: it is the first thing a new user reads.
+got=$(bash cyberaar-baseline.sh --help 2>/dev/null | grep -oP 'Baseline Checker v\K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+eq "cyberaar-baseline.sh --help banner" "$got" "$BASELINE_SRC"
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
The release that was supposed to make the numbers trustworthy shipped a script whose `--version` said **4.2.0** while the script was **4.3.0**.

Found by downloading the published release asset and running it, which is what a stranger does first.

## Three more literals, same mistake as the JSON renderer

| line | what |
|---|---|
| 6 | a header comment carrying the number a second time |
| 25 | the `--help` banner, inside a `cat <<'HELPEOF'` **quoted** heredoc, which is exactly why it could never drift back into line |
| 102 | the output of `--version` itself |

**The canonical way of asking a tool which version it is returned a lie.** On a security tool that is worse than cosmetic: the version is what an auditor records against the evidence, and what someone reads before deciding whether they have the build with a fix in it.

The heredoc is now unquoted. I checked first that nothing else inside it contains `$` or a backtick, so nothing else starts expanding.

## The guard only looked where I had already found the bug

`test_versions.sh` grew three assertions:

- no semver literal anywhere in either `main.sh` outside the one assignment
- `--version` output equals the declared version, for both bundles
- the `--help` banner equals it too, since it is the first thing anyone reads

Proven by putting the shipped literal back and watching both new assertions go red, then removing it again.

```
test_aartool 98 · test_docs 141 · test_distro 26
test_escaping 14 · test_remediation_map 437 · test_versions 15
shellcheck clean
```

Release assets for v3.0.0 need re-uploading with the corrected bundle.