### PR TITLE
docs: an install path that does not depend on Galaxy or a registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ scripts/aartool install --prefix ~/.local   # needs ~/.local/bin on PATH
 ./scripts/aartool advise                    # or just run it from the clone
 ```
 
+Or take the single file, on a machine you cannot clone onto. The audit script
+has no dependencies beyond the coreutils already there, which is what makes it
+work on an air-gapped box:
+
+```bash
+curl -fsSLO https://github.com/cyberaar/aartool/releases/latest/download/cyberaar-baseline.sh
+curl -fsSLO https://github.com/cyberaar/aartool/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+chmod +x cyberaar-baseline.sh && sudo ./cyberaar-baseline.sh
+```
+
+`aartool` and the Ansible collection tarball are attached to every release the
+same way, so neither Ansible Galaxy nor a container registry is on the critical
+path. Release assets do not carry the executable bit, hence the `chmod`. Verify
+against `SHA256SUMS`: for a tool that rewrites `sshd_config` and PAM, checking
+what you downloaded is not ceremony.
+
 Auditing the machine you are on still needs root either way: it reads
 `sshd_config`, `/etc/shadow`, the audit rules and sysctls. Auditing a *remote*
 host needs no privilege locally at all.

--- a/docs/AARTOOL.md
+++ b/docs/AARTOOL.md
@@ -80,6 +80,23 @@ Everything works from the clone:
 ./scripts/aartool inspect
 ```
 
+### Without cloning anything
+
+Every release attaches `aartool`, `cyberaar-baseline.sh`, the collection
+tarball and a `SHA256SUMS`. Neither Ansible Galaxy nor a container registry is
+on the critical path.
+
+```bash
+curl -fsSLO https://github.com/cyberaar/aartool/releases/latest/download/cyberaar-baseline.sh
+curl -fsSLO https://github.com/cyberaar/aartool/releases/latest/download/SHA256SUMS
+sha256sum -c SHA256SUMS --ignore-missing
+chmod +x cyberaar-baseline.sh && sudo ./cyberaar-baseline.sh
+```
+
+Assets do not carry the executable bit, hence the `chmod`. The single-file audit
+script is the one to take to an air-gapped machine; `aartool` needs the rest of
+the toolkit beside it, so clone or use the container for that.
+
 ### In a container
 
 The repository ships an execution environment with Ansible and the collections


### PR DESCRIPTION
Publishing v3.0.0 surfaced two things outside this repository's control:

- the **Ansible Galaxy API key is rejected with a 401**, so `cyberaar.hardening` 3.0.0 is not on Galaxy;
- **GHCR makes new packages private by default** and exposes no API to change it (404 on both the org and user PATCH endpoints), so `docker pull ghcr.io/cyberaar/aartool` returns `denied` for everyone but the owner.

Both need an account holder in a web UI. Until then **every install route the documentation offered was blocked for a stranger.**

The release page is public, so the assets go there: `aartool`, `cyberaar-baseline.sh`, the collection tarball and `SHA256SUMS`.

```bash
curl -fsSLO https://github.com/cyberaar/aartool/releases/latest/download/cyberaar-baseline.sh
curl -fsSLO https://github.com/cyberaar/aartool/releases/latest/download/SHA256SUMS
sha256sum -c SHA256SUMS --ignore-missing
chmod +x cyberaar-baseline.sh && sudo ./cyberaar-baseline.sh
```

Verified by downloading all four with no credentials, checking them against the manifest, running both scripts, and installing the collection with all 52 roles present.

This is not really a workaround. The audit script is a single dependency-free bash file **precisely so it can be carried onto a machine that cannot reach a registry**, and until now the only documented way to get it was to clone a repository.

Release assets do not preserve the executable bit, so the instructions carry the `chmod` rather than leaving people to discover it.