### PR TITLE
fix(SYS-10): a check that could never pass, on any host, ever

### DIFF
--- a/.github/workflows/baseline-build.yml
+++ b/.github/workflows/baseline-build.yml
@@ -88,5 +88,11 @@ jobs:
       - name: Versions agree across sources, bundles, reports and the image tag
         run: bash scripts/tests/test_versions.sh
 
+      # SYS-10 tested for Ctrl-Alt-Del masking with `systemctl is-masked`, a verb
+      # systemd does not have, so it reported FAIL on every host ever scanned.
+      # Subcommands the checks invoke are validated against the real tool's help.
+      - name: Checks call subcommands that exist
+        run: bash scripts/tests/test_check_commands.sh
+
       - name: Escaping regression tests
         run: bash scripts/tests/test_escaping.sh

--- a/ansible-hardening/roles/linux_authselect_ubuntu/defaults/main.yml
+++ b/ansible-hardening/roles/linux_authselect_ubuntu/defaults/main.yml
@@ -20,7 +20,16 @@ linux_authselect_even_deny_root: true
 linux_authselect_root_unlock_time: 60
 
 # Password aging (CIS 5.5.1.x)
-linux_authselect_pass_max_days: 365
+# 90, matching linux_user_management_rhel9's linux_password_max_days and the
+# AUTH-03 check, which passes at 90 or less. This was 365: the RHEL and Ubuntu
+# implementations of the same control disagreed with each other, and the Ubuntu
+# one disagreed with the audit, so applying the recommended remediation left the
+# finding failing. Every one of 15 audited Ubuntu nodes reported AUTH-03 FAIL.
+#
+# CIS Ubuntu 22.04 5.5.1.2 permits up to 365, and NIST SP 800-63B argues against
+# forced expiry altogether. If your policy says otherwise, override this; the
+# point is that the tool and its own remediation now agree on a number.
+linux_authselect_pass_max_days: 90
 linux_authselect_pass_min_days: 1
 linux_authselect_pass_warn_age: 7
 linux_authselect_pass_min_len: 14

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -1768,6 +1768,11 @@ Usage:
 Options:
   -t, --target HOST|GROUP   Host or inventory group. Required.
   -u, --user USER           SSH user (default: ansible)
+      --ssh-key FILE        SSH private key. inspect has always taken one;
+                            plan and apply did not, so on an estate with a
+                            dedicated key they failed with a permission error
+                            that pointed at the target rather than at the
+                            missing flag.
       --only TAGS           Limit to categories, comma separated.
                             e.g. ssh, firewall, audit, kernel, users
       --full                Run the three-step pipeline: audit, harden, audit.
@@ -1784,12 +1789,15 @@ EOF
 
 cmd_harden() {
   local mode="$1"; shift          # plan | apply
-  local target="" user="" tags="" full=false become=false assume_yes=false
+  local target="" user="" sshkey="" tags="" full=false become=false assume_yes=false
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -t|--target) [[ $# -ge 2 ]] || die "$1 needs a value."; target="$2"; shift 2 ;;
       -u|--user)   [[ $# -ge 2 ]] || die "$1 needs a value."; user="$2";   shift 2 ;;
+      --ssh-key)   [[ $# -ge 2 ]] || die "$1 needs a value."
+                   [[ -r "$2" ]] || die "SSH key not readable: $2"
+                   sshkey="$2"; shift 2 ;;
       --only)      [[ $# -ge 2 ]] || die "$1 needs a value."; tags="$2";   shift 2 ;;
       --full)      full=true;       shift ;;
       -K|--ask-become-pass) become=true; shift ;;
@@ -1814,6 +1822,7 @@ cmd_harden() {
 
   local -a args=(-t "$target" -s "$( [[ "$full" == true ]] && echo all || echo 2 )")
   [[ -n "$user" ]]      && args+=(-u "$user")
+  [[ -n "$sshkey" ]]    && args+=(-i "$sshkey")
   [[ -n "$tags" ]]      && args+=(-T "$tags")
   [[ "$become" == true ]] && args+=(-K)
   [[ "$mode" == plan ]] && args+=(-c)
@@ -2449,10 +2458,14 @@ cmd_doctor_usage() {
 aartool doctor: check everything plan and apply depend on. Changes nothing.
 
 Usage:
-  aartool doctor [--target HOST]
+  aartool doctor [--target HOST [--user USER] [--ssh-key FILE]]
 
 Options:
-      --target HOST   Also test SSH reachability and sudo on that host
+  -t, --target HOST   Also test SSH reachability and sudo on that host
+  -u, --user USER     SSH user for that test. Without it, ansible connects as
+                      whoever you are locally, which is almost never right on
+                      a real estate.
+      --ssh-key FILE  SSH private key for that test
   -h, --help          Show this help
 
 Exits non-zero if anything is missing, so it works as a CI gate.
@@ -2460,10 +2473,12 @@ EOF
 }
 
 cmd_doctor() {
-  local target=""
+  local target="" user="" sshkey=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -t|--target) [[ $# -ge 2 ]] || die "$1 needs a value."; target="$2"; shift 2 ;;
+      -u|--user)   [[ $# -ge 2 ]] || die "$1 needs a value."; user="$2";   shift 2 ;;
+      --ssh-key)   [[ $# -ge 2 ]] || die "$1 needs a value."; sshkey="$2"; shift 2 ;;
       -h|--help)   cmd_doctor_usage; return 0 ;;
       -*) die "Unknown option for doctor: $1." ;;
       *)  die "doctor takes no positional arguments." ;;
@@ -2529,10 +2544,33 @@ cmd_doctor() {
     elif ! command -v ansible >/dev/null 2>&1; then
       _doc_warn "target $target" "skipped" "ansible not on PATH"
     else
-      if ansible -i "$INVENTORY" "$target" -m ping >/dev/null 2>&1; then
-        _doc_pass "target $target" "reachable"
+      # Without -u, ansible connects as whoever is running this, which on a
+      # real estate is never the admin account. doctor reported "unreachable"
+      # for a host that was perfectly reachable, and the fix line it printed
+      # reproduced its own mistake. plan and apply have always taken --user;
+      # the check that exists to catch connection problems did not.
+      local -a probe=(-i "$INVENTORY" "$target" -m ping)
+      [[ -n "$user"   ]] && probe+=(-u "$user")
+      [[ -n "$sshkey" ]] && probe+=(--private-key "$sshkey")
+      vlog "probe: ansible ${probe[*]}"
+      if ansible "${probe[@]}" >/dev/null 2>&1; then
+        _doc_pass "target $target" "reachable$([[ -n "$user" ]] && printf ' as %s' "$user")"
+        # Reachable is not the same as able to change anything. plan is a dry
+        # run, but apply needs root, and finding that out at apply time means
+        # finding out halfway through a hardening run.
+        if ansible -i "$INVENTORY" "$target" -m raw -a 'sudo -n true' \
+             ${user:+-u "$user"} ${sshkey:+--private-key "$sshkey"} >/dev/null 2>&1; then
+          _doc_pass "sudo on $target" "passwordless"
+        else
+          _doc_warn "sudo on $target" "needs a password" \
+            "apply will stall unless you pass -K, or grant NOPASSWD to the automation account"
+        fi
       else
-        _doc_fail "target $target" "unreachable" "ansible -i $INVENTORY $target -m ping   (check SSH user and keys)"
+        local hint="ansible -i $INVENTORY $target -m ping"
+        [[ -n "$user"   ]] && hint+=" -u $user"
+        [[ -n "$sshkey" ]] && hint+=" --private-key $sshkey"
+        [[ -z "$user"   ]] && hint+="   (no --user given, so it tried as $(id -un))"
+        _doc_fail "target $target" "unreachable" "$hint"
       fi
     fi
   fi

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -305,7 +305,7 @@ AUTH-04 AUTH-09 AUTH-11 AUTH-15
 SYS-03 SYS-04 SYS-05 SYS-11
 NET-01 NET-02 NET-05
 LOG-01 LOG-04 LOG-08
-FS-01 FS-05 FS-06
+FS-01 FS-05 FS-06 FS-07
 IDS
 }
 
@@ -1404,6 +1404,45 @@ MORE
 E
   ;;
 
+  FS-07) cat <<'E'
+WHAT
+  World-writable directories that do not have the sticky bit set.
+
+WHY
+  Without the sticky bit, any user who can write to a directory can delete or
+  rename anyone else's files in it, not just their own. That is the mechanism
+  behind a whole family of symlink and rename races: an attacker swaps a file
+  another process is about to open, between the check and the open. /tmp is the
+  classic case, which is why /tmp has had the sticky bit since the 1980s.
+
+COST
+  Read the list before you act on it. On any host that runs containers, almost
+  every hit is inside the image and snapshot store, and those permissions
+  reflect the contents of the images rather than anything about this machine.
+  Mass-chmodding a snapshot tree corrupts layers and breaks the containers
+  built on them. On a real docs server all 3622 findings were under
+  /var/lib/containerd and not one of them was worth changing.
+
+BY HAND
+  # Look first, and group by where they actually live:
+  find / -xdev -type d -perm -0002 ! -perm -1000 2>/dev/null \
+    | cut -d/ -f1-4 | sort | uniq -c | sort -rn | head
+  # Then fix only what is genuinely yours:
+  find /srv /opt /home -xdev -type d -perm -0002 ! -perm -1000 \
+    -exec chmod a+t {} +
+
+WITH AARTOOL
+  aartool plan --target HOST --user USER --only filesystem,permissions
+  Read that plan rather than applying it blind. The role fixes the paths it
+  knows about; a container store is not one of them, and it should not be.
+
+MORE
+  Exclude the container root from the question instead of from the fix. If your
+  storage driver lives under /var/lib/docker or /var/lib/containerd, findings
+  there are about your images, and the place to fix them is the Dockerfile.
+E
+  ;;
+
   FS-05) cat <<'E'
 WHAT
   Unexpected setuid and setgid binaries on the filesystem.
@@ -2017,6 +2056,11 @@ _advise_costly() {
     SYS-04)                      return 0 ;;  # MAC enforcing without a permissive pass
     AUTH-04|AUTH-09|AUTH-14)     return 0 ;;  # PAM edits, self-inflicted lockout
     AUTH-05|AUTH-11|FS-05)       return 0 ;;  # needs a human: what IS that account/binary
+    # World-writable paths are overwhelmingly inside container storage on any
+    # host that runs containers, and mass-chmodding a snapshot tree corrupts
+    # image layers. Found on a real docs server where all 3622 hits were under
+    # /var/lib/containerd: the finding was true and the remediation was wrong.
+    FS-04|FS-07)                 return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/aartool-src/cmd/advise.sh
+++ b/scripts/aartool-src/cmd/advise.sh
@@ -34,6 +34,11 @@ _advise_costly() {
     SYS-04)                      return 0 ;;  # MAC enforcing without a permissive pass
     AUTH-04|AUTH-09|AUTH-14)     return 0 ;;  # PAM edits, self-inflicted lockout
     AUTH-05|AUTH-11|FS-05)       return 0 ;;  # needs a human: what IS that account/binary
+    # World-writable paths are overwhelmingly inside container storage on any
+    # host that runs containers, and mass-chmodding a snapshot tree corrupts
+    # image layers. Found on a real docs server where all 3622 hits were under
+    # /var/lib/containerd: the finding was true and the remediation was wrong.
+    FS-04|FS-07)                 return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/scripts/aartool-src/cmd/doctor.sh
+++ b/scripts/aartool-src/cmd/doctor.sh
@@ -24,10 +24,14 @@ cmd_doctor_usage() {
 aartool doctor: check everything plan and apply depend on. Changes nothing.
 
 Usage:
-  aartool doctor [--target HOST]
+  aartool doctor [--target HOST [--user USER] [--ssh-key FILE]]
 
 Options:
-      --target HOST   Also test SSH reachability and sudo on that host
+  -t, --target HOST   Also test SSH reachability and sudo on that host
+  -u, --user USER     SSH user for that test. Without it, ansible connects as
+                      whoever you are locally, which is almost never right on
+                      a real estate.
+      --ssh-key FILE  SSH private key for that test
   -h, --help          Show this help
 
 Exits non-zero if anything is missing, so it works as a CI gate.
@@ -35,10 +39,12 @@ EOF
 }
 
 cmd_doctor() {
-  local target=""
+  local target="" user="" sshkey=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -t|--target) [[ $# -ge 2 ]] || die "$1 needs a value."; target="$2"; shift 2 ;;
+      -u|--user)   [[ $# -ge 2 ]] || die "$1 needs a value."; user="$2";   shift 2 ;;
+      --ssh-key)   [[ $# -ge 2 ]] || die "$1 needs a value."; sshkey="$2"; shift 2 ;;
       -h|--help)   cmd_doctor_usage; return 0 ;;
       -*) die "Unknown option for doctor: $1." ;;
       *)  die "doctor takes no positional arguments." ;;
@@ -104,10 +110,33 @@ cmd_doctor() {
     elif ! command -v ansible >/dev/null 2>&1; then
       _doc_warn "target $target" "skipped" "ansible not on PATH"
     else
-      if ansible -i "$INVENTORY" "$target" -m ping >/dev/null 2>&1; then
-        _doc_pass "target $target" "reachable"
+      # Without -u, ansible connects as whoever is running this, which on a
+      # real estate is never the admin account. doctor reported "unreachable"
+      # for a host that was perfectly reachable, and the fix line it printed
+      # reproduced its own mistake. plan and apply have always taken --user;
+      # the check that exists to catch connection problems did not.
+      local -a probe=(-i "$INVENTORY" "$target" -m ping)
+      [[ -n "$user"   ]] && probe+=(-u "$user")
+      [[ -n "$sshkey" ]] && probe+=(--private-key "$sshkey")
+      vlog "probe: ansible ${probe[*]}"
+      if ansible "${probe[@]}" >/dev/null 2>&1; then
+        _doc_pass "target $target" "reachable$([[ -n "$user" ]] && printf ' as %s' "$user")"
+        # Reachable is not the same as able to change anything. plan is a dry
+        # run, but apply needs root, and finding that out at apply time means
+        # finding out halfway through a hardening run.
+        if ansible -i "$INVENTORY" "$target" -m raw -a 'sudo -n true' \
+             ${user:+-u "$user"} ${sshkey:+--private-key "$sshkey"} >/dev/null 2>&1; then
+          _doc_pass "sudo on $target" "passwordless"
+        else
+          _doc_warn "sudo on $target" "needs a password" \
+            "apply will stall unless you pass -K, or grant NOPASSWD to the automation account"
+        fi
       else
-        _doc_fail "target $target" "unreachable" "ansible -i $INVENTORY $target -m ping   (check SSH user and keys)"
+        local hint="ansible -i $INVENTORY $target -m ping"
+        [[ -n "$user"   ]] && hint+=" -u $user"
+        [[ -n "$sshkey" ]] && hint+=" --private-key $sshkey"
+        [[ -z "$user"   ]] && hint+="   (no --user given, so it tried as $(id -un))"
+        _doc_fail "target $target" "unreachable" "$hint"
       fi
     fi
   fi

--- a/scripts/aartool-src/cmd/harden.sh
+++ b/scripts/aartool-src/cmd/harden.sh
@@ -17,6 +17,11 @@ Usage:
 Options:
   -t, --target HOST|GROUP   Host or inventory group. Required.
   -u, --user USER           SSH user (default: ansible)
+      --ssh-key FILE        SSH private key. inspect has always taken one;
+                            plan and apply did not, so on an estate with a
+                            dedicated key they failed with a permission error
+                            that pointed at the target rather than at the
+                            missing flag.
       --only TAGS           Limit to categories, comma separated.
                             e.g. ssh, firewall, audit, kernel, users
       --full                Run the three-step pipeline: audit, harden, audit.
@@ -33,12 +38,15 @@ EOF
 
 cmd_harden() {
   local mode="$1"; shift          # plan | apply
-  local target="" user="" tags="" full=false become=false assume_yes=false
+  local target="" user="" sshkey="" tags="" full=false become=false assume_yes=false
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -t|--target) [[ $# -ge 2 ]] || die "$1 needs a value."; target="$2"; shift 2 ;;
       -u|--user)   [[ $# -ge 2 ]] || die "$1 needs a value."; user="$2";   shift 2 ;;
+      --ssh-key)   [[ $# -ge 2 ]] || die "$1 needs a value."
+                   [[ -r "$2" ]] || die "SSH key not readable: $2"
+                   sshkey="$2"; shift 2 ;;
       --only)      [[ $# -ge 2 ]] || die "$1 needs a value."; tags="$2";   shift 2 ;;
       --full)      full=true;       shift ;;
       -K|--ask-become-pass) become=true; shift ;;
@@ -63,6 +71,7 @@ cmd_harden() {
 
   local -a args=(-t "$target" -s "$( [[ "$full" == true ]] && echo all || echo 2 )")
   [[ -n "$user" ]]      && args+=(-u "$user")
+  [[ -n "$sshkey" ]]    && args+=(-i "$sshkey")
   [[ -n "$tags" ]]      && args+=(-T "$tags")
   [[ "$become" == true ]] && args+=(-K)
   [[ "$mode" == plan ]] && args+=(-c)

--- a/scripts/aartool-src/lib/kb.sh
+++ b/scripts/aartool-src/lib/kb.sh
@@ -24,7 +24,7 @@ AUTH-04 AUTH-09 AUTH-11 AUTH-15
 SYS-03 SYS-04 SYS-05 SYS-11
 NET-01 NET-02 NET-05
 LOG-01 LOG-04 LOG-08
-FS-01 FS-05 FS-06
+FS-01 FS-05 FS-06 FS-07
 IDS
 }
 
@@ -1120,6 +1120,45 @@ MORE
   If a package operation fails afterwards, point it at a directory you control
   rather than removing noexec:
     export TMPDIR=/var/lib/mytmp
+E
+  ;;
+
+  FS-07) cat <<'E'
+WHAT
+  World-writable directories that do not have the sticky bit set.
+
+WHY
+  Without the sticky bit, any user who can write to a directory can delete or
+  rename anyone else's files in it, not just their own. That is the mechanism
+  behind a whole family of symlink and rename races: an attacker swaps a file
+  another process is about to open, between the check and the open. /tmp is the
+  classic case, which is why /tmp has had the sticky bit since the 1980s.
+
+COST
+  Read the list before you act on it. On any host that runs containers, almost
+  every hit is inside the image and snapshot store, and those permissions
+  reflect the contents of the images rather than anything about this machine.
+  Mass-chmodding a snapshot tree corrupts layers and breaks the containers
+  built on them. On a real docs server all 3622 findings were under
+  /var/lib/containerd and not one of them was worth changing.
+
+BY HAND
+  # Look first, and group by where they actually live:
+  find / -xdev -type d -perm -0002 ! -perm -1000 2>/dev/null \
+    | cut -d/ -f1-4 | sort | uniq -c | sort -rn | head
+  # Then fix only what is genuinely yours:
+  find /srv /opt /home -xdev -type d -perm -0002 ! -perm -1000 \
+    -exec chmod a+t {} +
+
+WITH AARTOOL
+  aartool plan --target HOST --user USER --only filesystem,permissions
+  Read that plan rather than applying it blind. The role fixes the paths it
+  knows about; a container store is not one of them, and it should not be.
+
+MORE
+  Exclude the container root from the question instead of from the fix. If your
+  storage driver lives under /var/lib/docker or /var/lib/containerd, findings
+  there are about your images, and the place to fix them is the Dockerfile.
 E
   ;;
 

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -816,13 +816,28 @@ case "$_SYS_PKG" in
         "Appliquez: '$_SYS_PKG update --security -y'"
     fi ;;
   apt-get)
+    # Scoped to SECURITY updates, like the dnf and zypper branches above it.
+    #
+    # This counted every upgradable package, so the same check ID meant
+    # "unpatched CVEs" on RHEL and "any package is not the newest" on Debian.
+    # A docs server with unattended-upgrades running correctly, zero security
+    # updates outstanding and twenty routine ones reported exactly the same
+    # FAIL as a RHEL host with twenty unpatched CVEs. Anyone comparing an
+    # Ubuntu fleet against a RHEL fleet was reading two different questions.
+    #
+    # apt marks the origin in the simulated Inst line:
+    #   Inst libfoo [1.2] (1.3 Ubuntu:24.04/noble-security [amd64])
     apt-get update -qq 2>/dev/null || true
-    PENDING=$(apt-get -s upgrade 2>/dev/null | grep -c "^Inst" || true)
+    _SYS_APT_SIM=$(apt-get -s upgrade 2>/dev/null | grep "^Inst" || true)
+    PENDING=$(printf '%s\n' "$_SYS_APT_SIM" | grep -c -- '-security' || true)
+    _SYS_APT_TOTAL=$(printf '%s\n' "$_SYS_APT_SIM" | grep -c . || true)
     if [[ "$PENDING" -eq 0 ]]; then
-      add_result "System" "PASS" "SYS-03" "No pending updates" "Système à jour" "0 packages" ""
+      add_result "System" "PASS" "SYS-03" "No pending security updates" "Système à jour" \
+        "0 security (${_SYS_APT_TOTAL} total pending)" ""
     else
-      add_result "System" "FAIL" "SYS-03" "Pending updates" "Mises à jour en attente" "$PENDING package(s)" \
-        "Appliquez: 'apt-get upgrade -y'"
+      add_result "System" "FAIL" "SYS-03" "Pending security updates" "Mises à jour de sécurité en attente" \
+        "${PENDING} security (${_SYS_APT_TOTAL} total pending)" \
+        "Appliquez: 'apt-get upgrade -y' (ou laissez unattended-upgrades le faire)"
     fi ;;
   zypper)
     # list-patches --category security is the SUSE equivalent of --security.

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -984,10 +984,20 @@ else
 fi
 
 # SYS-10 Ctrl-Alt-Delete disabled
-if systemctl is-masked ctrl-alt-del.target &>/dev/null; then
-  add_result "System" "PASS" "SYS-10" "Ctrl-Alt-Del masked" "Ctrl-Alt-Suppr désactivé" "ctrl-alt-del.target: masked" ""
+#
+# `systemctl is-masked` is not a systemd verb. It never has been: systemd
+# answers "Unknown command verb 'is-masked', did you mean 'is-failed'?" and
+# exits non-zero, so this check reported FAIL on every host ever scanned,
+# including hosts where the target was correctly masked. Confirmed across a
+# 15-node estate: 15 FAIL, 0 PASS, every one of them masked.
+#
+# `is-enabled` is the verb that reports masking, and it prints "masked" for a
+# unit symlinked to /dev/null. Accept both "masked" and "masked-runtime".
+CAD_STATE=$(systemctl is-enabled ctrl-alt-del.target 2>/dev/null || true)
+if [[ "$CAD_STATE" == masked* ]]; then
+  add_result "System" "PASS" "SYS-10" "Ctrl-Alt-Del masked" "Ctrl-Alt-Suppr désactivé" "ctrl-alt-del.target: ${CAD_STATE}" ""
 else
-  add_result "System" "FAIL" "SYS-10" "Ctrl-Alt-Del not masked" "Ctrl-Alt-Suppr actif" "ctrl-alt-del.target: not masked" \
+  add_result "System" "FAIL" "SYS-10" "Ctrl-Alt-Del not masked" "Ctrl-Alt-Suppr actif" "ctrl-alt-del.target: ${CAD_STATE:-unknown}" \
     "Masquez: 'systemctl mask ctrl-alt-del.target && systemctl daemon-reload'"
 fi
 }

--- a/scripts/run-hardening.sh
+++ b/scripts/run-hardening.sh
@@ -58,17 +58,23 @@ ADMIN_USER="ansible"
 TARGET="linux_servers"
 STEP="2"
 HARDENING_TAGS="hardening"
+SSH_KEY=""
 CHECK_MODE=false
 ASK_BECOME_PASS=false
 LOG_DIR="$HOME/logs"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
-while getopts "u:t:s:T:Kch" opt; do
+while getopts "u:t:s:T:i:Kch" opt; do
   case $opt in
     u) ADMIN_USER="$OPTARG" ;;
     t) TARGET="$OPTARG" ;;
     s) STEP="$OPTARG" ;;
     T) HARDENING_TAGS="$OPTARG" ;;
+    # An estate with a dedicated key is the normal case, not the exception.
+    # Without this the only way to connect was to have the key in an agent or
+    # at a default path, and the failure looked like a permissions problem on
+    # the target rather than a missing flag here.
+    i) SSH_KEY="$OPTARG" ;;
     K) ASK_BECOME_PASS=true ;;
     c) CHECK_MODE=true ;;
     h) grep "^#" "$0" | grep -v "^#!/" | sed 's/^# \?//'; exit 0 ;;
@@ -150,6 +156,7 @@ BASE_FLAGS=(
   "-i" "$INVENTORY"
   "--extra-vars" "target=${TARGET}"
 )
+[[ -n "$SSH_KEY"      ]] && BASE_FLAGS+=("--private-key" "$SSH_KEY")
 [[ "$CHECK_MODE"      == true ]] && BASE_FLAGS+=("--check")
 [[ "$ASK_BECOME_PASS" == true ]] && BASE_FLAGS+=("--ask-become-pass")
 

--- a/scripts/src/checks/sys.sh
+++ b/scripts/src/checks/sys.sh
@@ -47,13 +47,28 @@ case "$_SYS_PKG" in
         "Appliquez: '$_SYS_PKG update --security -y'"
     fi ;;
   apt-get)
+    # Scoped to SECURITY updates, like the dnf and zypper branches above it.
+    #
+    # This counted every upgradable package, so the same check ID meant
+    # "unpatched CVEs" on RHEL and "any package is not the newest" on Debian.
+    # A docs server with unattended-upgrades running correctly, zero security
+    # updates outstanding and twenty routine ones reported exactly the same
+    # FAIL as a RHEL host with twenty unpatched CVEs. Anyone comparing an
+    # Ubuntu fleet against a RHEL fleet was reading two different questions.
+    #
+    # apt marks the origin in the simulated Inst line:
+    #   Inst libfoo [1.2] (1.3 Ubuntu:24.04/noble-security [amd64])
     apt-get update -qq 2>/dev/null || true
-    PENDING=$(apt-get -s upgrade 2>/dev/null | grep -c "^Inst" || true)
+    _SYS_APT_SIM=$(apt-get -s upgrade 2>/dev/null | grep "^Inst" || true)
+    PENDING=$(printf '%s\n' "$_SYS_APT_SIM" | grep -c -- '-security' || true)
+    _SYS_APT_TOTAL=$(printf '%s\n' "$_SYS_APT_SIM" | grep -c . || true)
     if [[ "$PENDING" -eq 0 ]]; then
-      add_result "System" "PASS" "SYS-03" "No pending updates" "Système à jour" "0 packages" ""
+      add_result "System" "PASS" "SYS-03" "No pending security updates" "Système à jour" \
+        "0 security (${_SYS_APT_TOTAL} total pending)" ""
     else
-      add_result "System" "FAIL" "SYS-03" "Pending updates" "Mises à jour en attente" "$PENDING package(s)" \
-        "Appliquez: 'apt-get upgrade -y'"
+      add_result "System" "FAIL" "SYS-03" "Pending security updates" "Mises à jour de sécurité en attente" \
+        "${PENDING} security (${_SYS_APT_TOTAL} total pending)" \
+        "Appliquez: 'apt-get upgrade -y' (ou laissez unattended-upgrades le faire)"
     fi ;;
   zypper)
     # list-patches --category security is the SUSE equivalent of --security.

--- a/scripts/src/checks/sys.sh
+++ b/scripts/src/checks/sys.sh
@@ -215,10 +215,20 @@ else
 fi
 
 # SYS-10 Ctrl-Alt-Delete disabled
-if systemctl is-masked ctrl-alt-del.target &>/dev/null; then
-  add_result "System" "PASS" "SYS-10" "Ctrl-Alt-Del masked" "Ctrl-Alt-Suppr désactivé" "ctrl-alt-del.target: masked" ""
+#
+# `systemctl is-masked` is not a systemd verb. It never has been: systemd
+# answers "Unknown command verb 'is-masked', did you mean 'is-failed'?" and
+# exits non-zero, so this check reported FAIL on every host ever scanned,
+# including hosts where the target was correctly masked. Confirmed across a
+# 15-node estate: 15 FAIL, 0 PASS, every one of them masked.
+#
+# `is-enabled` is the verb that reports masking, and it prints "masked" for a
+# unit symlinked to /dev/null. Accept both "masked" and "masked-runtime".
+CAD_STATE=$(systemctl is-enabled ctrl-alt-del.target 2>/dev/null || true)
+if [[ "$CAD_STATE" == masked* ]]; then
+  add_result "System" "PASS" "SYS-10" "Ctrl-Alt-Del masked" "Ctrl-Alt-Suppr désactivé" "ctrl-alt-del.target: ${CAD_STATE}" ""
 else
-  add_result "System" "FAIL" "SYS-10" "Ctrl-Alt-Del not masked" "Ctrl-Alt-Suppr actif" "ctrl-alt-del.target: not masked" \
+  add_result "System" "FAIL" "SYS-10" "Ctrl-Alt-Del not masked" "Ctrl-Alt-Suppr actif" "ctrl-alt-del.target: ${CAD_STATE:-unknown}" \
     "Masquez: 'systemctl mask ctrl-alt-del.target && systemctl daemon-reload'"
 fi
 }

--- a/scripts/tests/test_check_commands.sh
+++ b/scripts/tests/test_check_commands.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Do the checks call commands that exist?
+#
+# SYS-10 tested for Ctrl-Alt-Delete masking with `systemctl is-masked`, which is
+# not a systemd verb and never has been. systemd answers "Unknown command verb
+# 'is-masked'" and exits non-zero, so the check reported FAIL on every host ever
+# scanned, including hosts where the target was correctly masked. It was found
+# by auditing a real estate: 15 nodes, 15 FAIL, 0 PASS, every one of them masked.
+#
+# A check that can never pass is the mirror of a check that can never fail. Both
+# are worse than no check, because both look like information.
+#
+# This validates the subcommands the checks invoke against the real tool's own
+# help output, on whatever machine the tests run on.
+#
+# Run: bash scripts/tests/test_check_commands.sh
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS+1)); }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL  %s\n' "$*"; }
+
+# ── systemctl ────────────────────────────────────────────────────────────────
+if ! command -v systemctl >/dev/null 2>&1; then
+  printf 'SKIP  systemctl not present on this machine\n'
+else
+  # systemctl --help lists its verbs indented under section headings. Take any
+  # leading lowercase word that is followed by whitespace or an argument.
+  VERBS=$(systemctl --help 2>/dev/null \
+          | grep -oP '^\s{2}\K[a-z][a-z-]+(?=\s|$|\s+[A-Z\[])' | sort -u)
+  [[ -n "$VERBS" ]] || { printf 'SKIP  could not read systemctl verbs\n'; VERBS=""; }
+
+  if [[ -n "$VERBS" ]]; then
+    # Every `systemctl <verb>` the checks invoke, ignoring options.
+    # Strip comments first. The first version of this guard matched the very
+    # comment explaining the bug it was written to prevent, and reported the
+    # fixed file as still broken.
+    used=$(cat src/checks/*.sh | sed 's/#.*//' \
+           | grep -oP '\bsystemctl\s+(?:--?\S+\s+)*\K[a-z][a-z-]+' | sort -u)
+    for v in $used; do
+      if printf '%s\n' "$VERBS" | grep -qx "$v"; then
+        ok
+      else
+        bad "src/checks/ calls 'systemctl $v', which this systemd does not have"
+      fi
+    done
+    printf '  checked %d distinct systemctl verbs against systemd %s\n' \
+      "$(printf '%s\n' "$used" | grep -c .)" "$(systemctl --version | head -1 | awk '{print $2}')"
+  fi
+fi
+
+# ── The specific regression, named ───────────────────────────────────────────
+# Cheap, explicit, and survives a machine where the verb list cannot be read.
+if cat src/checks/*.sh | sed 's/#.*//' | grep -q 'systemctl is-masked'; then
+  bad "src/checks/ still uses 'systemctl is-masked'; the verb is 'is-enabled', which prints 'masked'"
+else
+  ok
+fi
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/tests/test_check_commands.sh
+++ b/scripts/tests/test_check_commands.sh
@@ -58,5 +58,25 @@ else
   ok
 fi
 
+# ── One check ID, one meaning, on every platform ─────────────────────────────
+# SYS-03 asked dnf and zypper for SECURITY updates and apt for ALL upgradable
+# packages, so the same finding meant "unpatched CVEs" on one fleet and "a
+# package is not the newest" on another. Anyone comparing the two was reading
+# two different questions and could not have known.
+sys03=$(sed -n '/^# SYS-03/,/^# SYS-04/p' src/checks/sys.sh)
+for branch in 'dnf|dnf5|yum' 'apt-get' 'zypper'; do
+  # Comments stripped. Twice now a guard in this file has matched the comment
+  # explaining the bug rather than the code, and passed on a file that still
+  # had the bug. Scan what runs, never what is written about what runs.
+  seg=$(printf '%s\n' "$sys03" | sed -n "/^  ${branch})/,/;;/p" | sed 's/#.*//')
+  if [[ -z "$seg" ]]; then
+    bad "SYS-03 has no '${branch}' branch any more; check this guard still matches the code"
+  elif printf '%s\n' "$seg" | grep -qiE '\-\-security|category security|\-security'; then
+    ok
+  else
+    bad "SYS-03's ${branch} branch does not scope to security updates, so it does not mean the same thing as the others"
+  fi
+done
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/scripts/tests/test_remediation_map.sh
+++ b/scripts/tests/test_remediation_map.sh
@@ -91,5 +91,37 @@ if [[ -d "$MOL_DIR" && -f "$CI" ]]; then
   done <<<"$in_ci"
 fi
 
+# ── A role default must satisfy the check it remediates ──────────────────────
+# The deepest version of "advice that does not work". Not a wrong tag, not a
+# missing role: the role runs, succeeds, and writes a value the checker rejects.
+# AUTH-03 demanded PASS_MAX_DAYS <= 90 while linux_authselect_ubuntu defaulted
+# to 365, so an operator could apply the recommended fix, re-audit, and see no
+# change. Forever. Meanwhile the RHEL role for the same control used 90, so the
+# two platforms disagreed with each other as well.
+#
+# One row per pair we have actually reasoned about. Not exhaustive, and not
+# meant to be: it exists so a known contradiction cannot come back.
+#   check | file | variable | operator | bound
+while IFS='|' read -r cid file var op bound; do
+  [[ -z "$cid" || "$cid" == \#* ]] && continue
+  path="../ansible-hardening/roles/$file/defaults/main.yml"
+  if [[ ! -f "$path" ]]; then
+    fail "$cid: $path does not exist"; continue
+  fi
+  val=$(grep -oP "^${var}:\s*\K[0-9]+" "$path" | head -1)
+  if [[ -z "$val" ]]; then
+    fail "$cid: $var not found in $file/defaults/main.yml"
+  elif [[ "$op" == "le" && "$val" -le "$bound" ]] || [[ "$op" == "ge" && "$val" -ge "$bound" ]]; then
+    PASS=$((PASS + 1))
+  else
+    fail "$cid: $file sets $var=$val, but the check requires $op $bound, so applying the remediation cannot clear the finding"
+  fi
+done <<'PAIRS'
+AUTH-03|linux_authselect_ubuntu|linux_authselect_pass_max_days|le|90
+AUTH-03|linux_user_management_rhel9|linux_password_max_days|le|90
+AUTH-07|linux_authselect_ubuntu|linux_authselect_pass_min_days|ge|1
+AUTH-08|linux_authselect_ubuntu|linux_authselect_pass_warn_age|ge|7
+PAIRS
+
 printf '\n%d assertions passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
`systemctl is-masked` **is not a systemd verb** and never has been. systemd answers

```
Unknown command verb 'is-masked', did you mean 'is-failed'?
```

and exits non-zero, so `SYS-10` reported **FAIL on every host this tool has ever scanned**, including hosts where `ctrl-alt-del.target` was correctly masked.

## How it surfaced

While preparing to apply hardening to a real docs server. The audit said *"Ctrl-Alt-Del not masked"*; the machine had `/etc/systemd/system/ctrl-alt-del.target -> /dev/null`, which is what masked means.

Checked against the whole estate afterwards:

```
SYS-10 across the 15 audited nodes: {'FAIL': 15}
never passes on: 15 of 15
```

**A check that can never pass is the mirror of a check that can never fail.** Both are worse than no check at all, because both look like information. This one had been quietly inflating the failure count of every report the tool has produced, and would have sent someone to "fix" a setting that was already correct.

## The fix

`is-enabled` is the verb that reports masking; it prints `masked` for a unit symlinked to `/dev/null`. Both `masked` and `masked-runtime` are accepted, and the **observed state is printed as evidence** instead of the assumption.

Verified against the real host: `✅ PASS SYS-10 Ctrl-Alt-Del masked — ctrl-alt-del.target: masked`.

## The guard

`test_check_commands.sh` validates every `systemctl <verb>` the checks invoke against the real tool's own `--help`, plus a named assertion for this verb so it still works where the verb list cannot be read.

It earned its own bug immediately: **the first version matched the comment explaining the fix** and reported the corrected file as still broken. Comments are stripped before scanning now. Proven by reintroducing `is-masked` and watching both assertions go red.