### PR TITLE
feat(report): --anonymise, so an audit can be shown to someone outside the estate

### DIFF
--- a/docs/AARTOOL.md
+++ b/docs/AARTOOL.md
@@ -355,6 +355,28 @@ drop-in file you can delete to revert.
 | `--out FILE` | One self-contained HTML file with the results already inside |
 | `--open` | Open the dashboard in a browser |
 | `--serve PORT` | Serve it on `127.0.0.1` only |
+| `--anonymise` | Replace every hostname with `server-01`, `server-02`, ... and every IP with `ip-01`, ... consistently across all reports. Prints the mapping once and stores it nowhere |
+| `--redact PAT` | Also replace this literal string everywhere. Repeatable, for the things only you know identify you |
+
+An audit report is a list of a machine's weaknesses with its name attached.
+There are good reasons to show one to somebody: a client, a talk, a post
+explaining the tool. There is no good reason to hand over the hostnames while
+doing it.
+
+```bash
+aartool report ./reports/*.json --anonymise --out share.html
+```
+
+The substitution is literal and global, not a field rewrite, because a hostname
+does not only live in the `host` key: it turns up in evidence strings and
+remediation hints too. Renaming the key alone produces a document that looks
+anonymised and is not, which is worse than not trying.
+
+`--redact` refuses a pattern that also appears in the report's own structural
+fields. `--redact cyberaar` would rewrite every `cyberaar_baseline` key, and the
+result is a valid HTML file that opens to an empty page. aartool checks the
+finished artefact for that too, rather than trusting the transformation that
+produced it.
 
 `--serve` binds to loopback and says so, because this renders audit results for
 an entire estate and has no authentication. Reach it with

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -2612,6 +2612,13 @@ Options:
                     server: run it there, then tunnel with
                       ssh -L PORT:127.0.0.1:PORT user@host
       --open        Try to open the result in a browser
+      --anonymise   Replace every hostname with server-01, server-02, ... and
+                    every IP address with ip-01, ip-02, ... consistently across
+                    all reports, so the file can be shared outside the estate
+                    it came from. Prints the mapping and what it changed.
+      --redact PAT  Also replace this literal string everywhere. Repeatable.
+                    For the things only you know are identifying: a client name,
+                    a project codename, an admin account.
   -h, --help        Show this help
 
 With no arguments it opens the empty dashboard, where you can drag reports in
@@ -2619,6 +2626,9 @@ yourself.
 
   sudo aartool inspect --out /tmp/audit
   aartool report /tmp/audit/*.json --out fleet.html
+
+  # A version you can hand to someone outside the estate
+  aartool report /tmp/audit/*.json --anonymise --redact acme-corp --out share.html
 EOF
 }
 
@@ -2628,15 +2638,131 @@ EOF
 # their \u form keeps the document valid and closes the hole.
 _report_js_safe() { sed -e 's|<|\\u003c|g' -e 's|>|\\u003e|g'; }
 
+# ── Anonymising ───────────────────────────────────────────────────────────────
+# An audit report is a list of a machine's weaknesses with its name attached.
+# There are good reasons to show one to somebody: a client, a conference talk, a
+# post explaining the tool. There is no good reason to hand over the hostnames
+# while doing it.
+#
+# The substitution is literal and global, not a field rewrite. A hostname does
+# not only live in the "host" key; it turns up in evidence strings, in
+# remediation hints, in whatever a check happened to capture. Replacing the key
+# alone produces a document that looks anonymised and is not, which is worse
+# than not trying.
+#
+# It builds one mapping across every input file, so the same machine is the same
+# server-NN in all of them and a before/after pair still lines up.
+_report_anon_sed=""
+_report_anon_map=""
+
+_report_build_anon() {
+  local -n _files_ref="$1"; shift
+  local -a extra=("$@")
+  local f name ip n=0 script="" map=""
+
+  # Longest first. Replacing "web-01" before "web-01.example.com" would leave
+  # "server-04.example.com" behind, which still names the domain.
+  local hosts
+  hosts=$(grep -ho '"host":[[:space:]]*"[^"]*"' "${_files_ref[@]}" 2>/dev/null \
+          | sed 's/.*"host":[[:space:]]*"//; s/"$//' | sort -u \
+          | awk '{ print length, $0 }' | sort -rn | cut -d' ' -f2- || true)
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    n=$((n+1))
+    local alias; alias=$(printf 'server-%02d' "$n")
+    script+="s|$(_report_sed_escape "$name")|${alias}|g;"
+    map+="  ${name}  ->  ${alias}"$'\n'
+  done <<<"$hosts"
+
+  # Addresses, in the order they first appear so the numbering is stable.
+  local ips
+  ips=$(grep -hoE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' "${_files_ref[@]}" 2>/dev/null | sort -u || true)
+  local m=0
+  while IFS= read -r ip; do
+    [[ -z "$ip" ]] && continue
+    m=$((m+1))
+    script+="s|$(_report_sed_escape "$ip")|$(printf 'ip-%02d' "$m")|g;"
+  done <<<"$ips"
+  [[ "$m" -gt 0 ]] && map+="  ${m} IP address(es)  ->  ip-01 .. $(printf 'ip-%02d' "$m")"$'\n'
+
+  # --redact is a literal global substitution, which is what makes it useful and
+  # also what makes it dangerous: the report's own structural keys are just
+  # strings in the same document. `--redact cyberaar` rewrote every
+  # "cyberaar_baseline" key to "REDACTED_baseline", the dashboard's bootstrap
+  # found no reports to load, and the output was a perfectly valid HTML file
+  # showing an empty page. Refuse instead, and say why.
+  local schema="cyberaar_baseline host os date score summary results id category status check detail remediation ansible_remediation remediation_tags version fail_ids warn_ids playbook inventory pass warn fail total"
+  local e k
+  for e in ${extra[@]+"${extra[@]}"}; do
+    for k in $schema; do
+      if [[ "$k" == *"$e"* ]]; then
+        die "--redact '$e' would also rewrite the report's own '$k' field, and the
+        output would render an empty dashboard. Pick a more specific string, or
+        drop it: hostnames and addresses are already handled by --anonymise."
+      fi
+    done
+    script+="s|$(_report_sed_escape "$e")|REDACTED|g;"
+    map+="  ${e}  ->  REDACTED"$'\n'
+  done
+
+  _report_anon_sed="$script"
+  _report_anon_map="$map"
+}
+
+# A hostname can legitimately contain characters sed treats as syntax, and the
+# pipe has to be escaped too because it is also the s||| delimiter here. The
+# first version of this used a sed bracket expression containing a pipe, which
+# sed read as the end of the pattern, so it silently produced a broken script
+# and the whole command exited 1 with no message. Parameter expansion has no
+# delimiter to collide with.
+_report_sed_escape() {
+  local t="$1"
+  t="${t//\\/\\\\}"          # backslash first, or it doubles the others
+  t="${t//|/\\|}"
+  t="${t//./\\.}"
+  t="${t//\*/\\*}"
+  t="${t//\[/\\[}"
+  t="${t//\]/\\]}"
+  t="${t//^/\\^}"
+  t="${t//\$/\\$}"
+  t="${t//&/\\&}"
+  t="${t//\//\\/}"
+  printf '%s' "$t"
+}
+
+# What a reader would still be able to identify. Printed after the fact rather
+# than silently trusted, because the operator knows things this cannot: a client
+# name, an internal codename, a person.
+_report_anon_warn() {
+  local file="$1" leaks="" data
+  # Only the injected data. The dashboard above it contains example commands
+  # with an example address in them, so scanning the whole file warned on every
+  # single run, and a warning that always fires is one people stop reading.
+  data=$(sed -n '/Injected by aartool/,$p' "$file" 2>/dev/null || true)
+  [[ -n "$data" ]] || return 0
+  grep -qE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' <<<"$data" && leaks+=" an IP address,"
+  # Any host value that is not one of ours. Written as a positive match on what
+  # a real hostname looks like, because grep -E has no negative lookahead and
+  # the version that pretended otherwise checked nothing at all.
+  grep -o '"host":[[:space:]]*"[^"]*"' <<<"$data" 2>/dev/null \
+    | grep -qv '"server-[0-9]' && leaks+=" a hostname,"
+  if [[ -n "$leaks" ]]; then
+    warn "After anonymising, the output still contains:${leaks%,}"
+    warn "Read it before you publish it."
+  fi
+}
+
 cmd_report() {
-  local out="" serve="" do_open=false
-  local -a files=()
+  local out="" serve="" do_open=false anon=false
+  local -a files=() redact=()
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -o|--out)  [[ $# -ge 2 ]] || die "$1 needs a file path."; out="$2"; shift 2 ;;
       --serve)   [[ $# -ge 2 ]] || die "--serve needs a port."; serve="$2"; shift 2 ;;
       --open)    do_open=true; shift ;;
+      --anonymise|--anonymize) anon=true; shift ;;
+      --redact)  [[ $# -ge 2 ]] || die "--redact needs a string."; redact+=("$2"); shift 2 ;;
       -h|--help) cmd_report_usage; return 0 ;;
       --) shift; while [[ $# -gt 0 ]]; do files+=("$1"); shift; done ;;
       -*) die "Unknown option for report: $1. Try 'aartool report --help'." ;;
@@ -2684,6 +2810,12 @@ cmd_report() {
   local target="${out:-$(mktemp -t aartool-report-XXXXXX.html)}"
   cp "$dash" "$target" || die "Cannot write $target"
 
+  if [[ "$anon" == true ]]; then
+    _report_build_anon files ${redact[@]+"${redact[@]}"}
+    info "Anonymised. The mapping is printed once, here, and stored nowhere:"
+    printf '%s' "$_report_anon_map"
+  fi
+
   {
     printf '\n<script>\n'
     printf '// Injected by aartool %s. The dashboard is unmodified above this line.\n' "$AARTOOL_VERSION"
@@ -2692,7 +2824,11 @@ cmd_report() {
     for f in "${files[@]}"; do
       [[ "$first" == true ]] || printf ',\n'
       first=false
-      _report_js_safe < "$f"
+      if [[ "$anon" == true ]]; then
+        sed "$_report_anon_sed" < "$f" | _report_js_safe
+      else
+        _report_js_safe < "$f"
+      fi
     done
     printf '\n  ];\n'
     cat <<'JS'
@@ -2714,6 +2850,20 @@ cmd_report() {
 JS
     printf '</script>\n'
   } >> "$target"
+
+  # Verify the artefact rather than trusting the transformation that produced
+  # it. Anonymising rewrites the document with a generated sed script; if that
+  # script touches something structural the file is still valid HTML and still
+  # opens, and shows nothing at all.
+  local embedded
+  embedded=$(grep -c '"cyberaar_baseline"' "$target" || true)
+  if [[ "$embedded" -lt "${#files[@]}" ]]; then
+    die "Only ${embedded} of ${#files[@]} reports survived into $target with an intact
+        structure, so it would open empty. This is a bug in aartool, not in your
+        input; please report it with the flags you used."
+  fi
+
+  [[ "$anon" == true ]] && _report_anon_warn "$target"
 
   local n="${#files[@]}"
   if [[ -n "$out" ]]; then

--- a/scripts/aartool-src/cmd/report.sh
+++ b/scripts/aartool-src/cmd/report.sh
@@ -26,6 +26,13 @@ Options:
                     server: run it there, then tunnel with
                       ssh -L PORT:127.0.0.1:PORT user@host
       --open        Try to open the result in a browser
+      --anonymise   Replace every hostname with server-01, server-02, ... and
+                    every IP address with ip-01, ip-02, ... consistently across
+                    all reports, so the file can be shared outside the estate
+                    it came from. Prints the mapping and what it changed.
+      --redact PAT  Also replace this literal string everywhere. Repeatable.
+                    For the things only you know are identifying: a client name,
+                    a project codename, an admin account.
   -h, --help        Show this help
 
 With no arguments it opens the empty dashboard, where you can drag reports in
@@ -33,6 +40,9 @@ yourself.
 
   sudo aartool inspect --out /tmp/audit
   aartool report /tmp/audit/*.json --out fleet.html
+
+  # A version you can hand to someone outside the estate
+  aartool report /tmp/audit/*.json --anonymise --redact acme-corp --out share.html
 EOF
 }
 
@@ -42,15 +52,131 @@ EOF
 # their \u form keeps the document valid and closes the hole.
 _report_js_safe() { sed -e 's|<|\\u003c|g' -e 's|>|\\u003e|g'; }
 
+# ── Anonymising ───────────────────────────────────────────────────────────────
+# An audit report is a list of a machine's weaknesses with its name attached.
+# There are good reasons to show one to somebody: a client, a conference talk, a
+# post explaining the tool. There is no good reason to hand over the hostnames
+# while doing it.
+#
+# The substitution is literal and global, not a field rewrite. A hostname does
+# not only live in the "host" key; it turns up in evidence strings, in
+# remediation hints, in whatever a check happened to capture. Replacing the key
+# alone produces a document that looks anonymised and is not, which is worse
+# than not trying.
+#
+# It builds one mapping across every input file, so the same machine is the same
+# server-NN in all of them and a before/after pair still lines up.
+_report_anon_sed=""
+_report_anon_map=""
+
+_report_build_anon() {
+  local -n _files_ref="$1"; shift
+  local -a extra=("$@")
+  local f name ip n=0 script="" map=""
+
+  # Longest first. Replacing "web-01" before "web-01.example.com" would leave
+  # "server-04.example.com" behind, which still names the domain.
+  local hosts
+  hosts=$(grep -ho '"host":[[:space:]]*"[^"]*"' "${_files_ref[@]}" 2>/dev/null \
+          | sed 's/.*"host":[[:space:]]*"//; s/"$//' | sort -u \
+          | awk '{ print length, $0 }' | sort -rn | cut -d' ' -f2- || true)
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    n=$((n+1))
+    local alias; alias=$(printf 'server-%02d' "$n")
+    script+="s|$(_report_sed_escape "$name")|${alias}|g;"
+    map+="  ${name}  ->  ${alias}"$'\n'
+  done <<<"$hosts"
+
+  # Addresses, in the order they first appear so the numbering is stable.
+  local ips
+  ips=$(grep -hoE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' "${_files_ref[@]}" 2>/dev/null | sort -u || true)
+  local m=0
+  while IFS= read -r ip; do
+    [[ -z "$ip" ]] && continue
+    m=$((m+1))
+    script+="s|$(_report_sed_escape "$ip")|$(printf 'ip-%02d' "$m")|g;"
+  done <<<"$ips"
+  [[ "$m" -gt 0 ]] && map+="  ${m} IP address(es)  ->  ip-01 .. $(printf 'ip-%02d' "$m")"$'\n'
+
+  # --redact is a literal global substitution, which is what makes it useful and
+  # also what makes it dangerous: the report's own structural keys are just
+  # strings in the same document. `--redact cyberaar` rewrote every
+  # "cyberaar_baseline" key to "REDACTED_baseline", the dashboard's bootstrap
+  # found no reports to load, and the output was a perfectly valid HTML file
+  # showing an empty page. Refuse instead, and say why.
+  local schema="cyberaar_baseline host os date score summary results id category status check detail remediation ansible_remediation remediation_tags version fail_ids warn_ids playbook inventory pass warn fail total"
+  local e k
+  for e in ${extra[@]+"${extra[@]}"}; do
+    for k in $schema; do
+      if [[ "$k" == *"$e"* ]]; then
+        die "--redact '$e' would also rewrite the report's own '$k' field, and the
+        output would render an empty dashboard. Pick a more specific string, or
+        drop it: hostnames and addresses are already handled by --anonymise."
+      fi
+    done
+    script+="s|$(_report_sed_escape "$e")|REDACTED|g;"
+    map+="  ${e}  ->  REDACTED"$'\n'
+  done
+
+  _report_anon_sed="$script"
+  _report_anon_map="$map"
+}
+
+# A hostname can legitimately contain characters sed treats as syntax, and the
+# pipe has to be escaped too because it is also the s||| delimiter here. The
+# first version of this used a sed bracket expression containing a pipe, which
+# sed read as the end of the pattern, so it silently produced a broken script
+# and the whole command exited 1 with no message. Parameter expansion has no
+# delimiter to collide with.
+_report_sed_escape() {
+  local t="$1"
+  t="${t//\\/\\\\}"          # backslash first, or it doubles the others
+  t="${t//|/\\|}"
+  t="${t//./\\.}"
+  t="${t//\*/\\*}"
+  t="${t//\[/\\[}"
+  t="${t//\]/\\]}"
+  t="${t//^/\\^}"
+  t="${t//\$/\\$}"
+  t="${t//&/\\&}"
+  t="${t//\//\\/}"
+  printf '%s' "$t"
+}
+
+# What a reader would still be able to identify. Printed after the fact rather
+# than silently trusted, because the operator knows things this cannot: a client
+# name, an internal codename, a person.
+_report_anon_warn() {
+  local file="$1" leaks="" data
+  # Only the injected data. The dashboard above it contains example commands
+  # with an example address in them, so scanning the whole file warned on every
+  # single run, and a warning that always fires is one people stop reading.
+  data=$(sed -n '/Injected by aartool/,$p' "$file" 2>/dev/null || true)
+  [[ -n "$data" ]] || return 0
+  grep -qE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' <<<"$data" && leaks+=" an IP address,"
+  # Any host value that is not one of ours. Written as a positive match on what
+  # a real hostname looks like, because grep -E has no negative lookahead and
+  # the version that pretended otherwise checked nothing at all.
+  grep -o '"host":[[:space:]]*"[^"]*"' <<<"$data" 2>/dev/null \
+    | grep -qv '"server-[0-9]' && leaks+=" a hostname,"
+  if [[ -n "$leaks" ]]; then
+    warn "After anonymising, the output still contains:${leaks%,}"
+    warn "Read it before you publish it."
+  fi
+}
+
 cmd_report() {
-  local out="" serve="" do_open=false
-  local -a files=()
+  local out="" serve="" do_open=false anon=false
+  local -a files=() redact=()
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -o|--out)  [[ $# -ge 2 ]] || die "$1 needs a file path."; out="$2"; shift 2 ;;
       --serve)   [[ $# -ge 2 ]] || die "--serve needs a port."; serve="$2"; shift 2 ;;
       --open)    do_open=true; shift ;;
+      --anonymise|--anonymize) anon=true; shift ;;
+      --redact)  [[ $# -ge 2 ]] || die "--redact needs a string."; redact+=("$2"); shift 2 ;;
       -h|--help) cmd_report_usage; return 0 ;;
       --) shift; while [[ $# -gt 0 ]]; do files+=("$1"); shift; done ;;
       -*) die "Unknown option for report: $1. Try 'aartool report --help'." ;;
@@ -98,6 +224,12 @@ cmd_report() {
   local target="${out:-$(mktemp -t aartool-report-XXXXXX.html)}"
   cp "$dash" "$target" || die "Cannot write $target"
 
+  if [[ "$anon" == true ]]; then
+    _report_build_anon files ${redact[@]+"${redact[@]}"}
+    info "Anonymised. The mapping is printed once, here, and stored nowhere:"
+    printf '%s' "$_report_anon_map"
+  fi
+
   {
     printf '\n<script>\n'
     printf '// Injected by aartool %s. The dashboard is unmodified above this line.\n' "$AARTOOL_VERSION"
@@ -106,7 +238,11 @@ cmd_report() {
     for f in "${files[@]}"; do
       [[ "$first" == true ]] || printf ',\n'
       first=false
-      _report_js_safe < "$f"
+      if [[ "$anon" == true ]]; then
+        sed "$_report_anon_sed" < "$f" | _report_js_safe
+      else
+        _report_js_safe < "$f"
+      fi
     done
     printf '\n  ];\n'
     cat <<'JS'
@@ -128,6 +264,20 @@ cmd_report() {
 JS
     printf '</script>\n'
   } >> "$target"
+
+  # Verify the artefact rather than trusting the transformation that produced
+  # it. Anonymising rewrites the document with a generated sed script; if that
+  # script touches something structural the file is still valid HTML and still
+  # opens, and shows nothing at all.
+  local embedded
+  embedded=$(grep -c '"cyberaar_baseline"' "$target" || true)
+  if [[ "$embedded" -lt "${#files[@]}" ]]; then
+    die "Only ${embedded} of ${#files[@]} reports survived into $target with an intact
+        structure, so it would open empty. This is a bug in aartool, not in your
+        input; please report it with the flags you used."
+  fi
+
+  [[ "$anon" == true ]] && _report_anon_warn "$target"
 
   local n="${#files[@]}"
   if [[ -n "$out" ]]; then

--- a/scripts/tests/test_dashboard.sh
+++ b/scripts/tests/test_dashboard.sh
@@ -141,5 +141,37 @@ else
   printf 'SKIP  node not available, render test not run\n'
 fi
 
+# ── Anonymising must not break the document it anonymises ────────────────────
+# --redact is a literal global substitution over the whole JSON, and the
+# report's structural keys are strings in that same document. `--redact
+# cyberaar` rewrote every "cyberaar_baseline" key, the bootstrap found no
+# reports, and the output was a valid HTML file showing an empty page. Valid,
+# openable, and containing nothing.
+if command -v node >/dev/null 2>&1 && [[ -f tests/fixtures/audit-fixture.json ]]; then
+  _tmp=$(mktemp -d); trap 'rm -rf "$_tmp"' EXIT
+
+  if bash ./aartool report tests/fixtures/audit-fixture.json --anonymise \
+       --out "$_tmp/anon.html" >/dev/null 2>&1; then
+    ok
+    n=$(grep -c '"cyberaar_baseline"' "$_tmp/anon.html" || true)
+    [[ "$n" -ge 1 ]] && ok || bad "the anonymised output lost its schema key, so it renders empty"
+
+    data=$(sed -n '/Injected by aartool/,$p' "$_tmp/anon.html")
+    if grep -q '"host":[[:space:]]*"server-' <<<"$data"; then ok
+    else bad "the anonymised output did not rename the host"; fi
+    if grep -q 'proof-target-01\|fixture-web-01' <<<"$data"; then
+      bad "the original hostname survived anonymising"
+    else ok; fi
+  else
+    bad "aartool report --anonymise failed on the fixture"
+  fi
+
+  # And the refusal that prevents the schema-key case entirely.
+  if bash ./aartool report tests/fixtures/audit-fixture.json --anonymise \
+       --redact cyberaar --out "$_tmp/bad.html" >/dev/null 2>&1; then
+    bad "--redact cyberaar was accepted; it rewrites the report's own schema key and the output renders nothing"
+  else ok; fi
+fi
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
An audit report is a list of a machine's weaknesses **with its name attached**. There are good reasons to show one to somebody: a client, a talk, a post explaining the tool. There is no good reason to hand over the hostnames while doing it, and until now the only options were publish as-is or edit JSON by hand.

```bash
aartool report ./reports/*.json --anonymise --out share.html
```

Hostnames become `server-01`, addresses become `ip-01`, consistently across every input file so a before/after pair still lines up. The mapping is printed once and stored nowhere. `--redact` takes literal strings for the things only the operator knows identify them.

The substitution is **literal and global, not a field rewrite**: a hostname does not only live in the `host` key, it turns up in evidence strings and remediation hints. Renaming the key alone produces a document that looks anonymised and is not, which is worse than not trying.

## What it cost to get right

Three bugs, all found by using it on a real estate rather than by review.

1. The sed-escaping helper built a character class **containing a pipe** inside an `s|...|` expression, so sed read the pattern as ending early. The command exited 1 with no output at all.
2. `grep` returning 1 on no match, inside a command substitution, under `set -euo pipefail`. There are no IPs in a report body, so the feature **died silently on exactly the normal case**. Third time for this shape.
3. **The one that matters.** `--redact` is a literal substitution over the whole document, and the report's structural keys are strings in that same document. `--redact cyberaar` rewrote every `cyberaar_baseline` key. The bootstrap found no reports, and the output was a perfectly valid HTML file that opened to an **empty page**. I nearly handed that file over.

   Two defences now: `--redact` **refuses** a pattern that also appears in a structural field and says why, and the finished artefact is checked for the expected number of intact reports rather than the transformation being trusted. A generated sed script is exactly the kind of thing that succeeds and produces nothing.

The leak warning was also scanning the whole output, including the dashboard's own example commands, so it **fired on every run**. A warning that always fires is one people stop reading. It looks only at the injected data now.

## Guards

Anonymising a fixture renames the host and keeps the schema key, the original hostname does not survive, and `--redact cyberaar` is refused. **Proven by disabling both defences and watching the test go red** (with only one disabled it still passed, because the other caught it).

```
test_dashboard 29 · test_docs 155 · test_aartool 98 · test_check_commands 11
test_distro 26 · test_escaping 14 · test_remediation_map 441 · test_versions 15
shellcheck clean
```