### PR TITLE
feat(cli): a banner on the human-facing paths, with an ASCII fallback

### DIFF
--- a/scripts/aartool
+++ b/scripts/aartool
@@ -61,10 +61,49 @@ vrun() {
   "$@"
 }
 
-usage() {
-  cat <<'EOF'
-aartool: CyberAar hardening toolkit
+# The banner prints on the human-facing paths only: a bare invocation and
+# --help. Not on --version, which is parsed by scripts and by our own tests, and
+# not on every subcommand, where it would be noise in front of the output you
+# actually asked for.
+#
+# Two versions. The block one reads at any size and is what the published
+# screenshots show; the ASCII one is for a terminal that cannot render those
+# glyphs, which on the machines this tool is pointed at is not hypothetical: a
+# serial console on a hardened box, a rescue shell, a locale set to C. The
+# fallback is chosen from the locale rather than attempted and repaired, because
+# there is no way to un-print a line of boxes.
+banner() {
+  printf '%s' "$CYAN"
+  case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *UTF-8*|*utf8*|*UTF8*)
+      cat <<'ART'
+ █████╗  █████╗ ██████╗ ████████╗ ██████╗  ██████╗ ██╗
+██╔══██╗██╔══██╗██╔══██╗╚══██╔══╝██╔═══██╗██╔═══██╗██║
+███████║███████║██████╔╝   ██║   ██║   ██║██║   ██║██║
+██╔══██║██╔══██║██╔══██╗   ██║   ██║   ██║██║   ██║██║
+██║  ██║██║  ██║██║  ██║   ██║   ╚██████╔╝╚██████╔╝███████╗
+╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝    ╚═════╝  ╚═════╝ ╚══════╝
+ART
+      ;;
+    *)
+      cat <<'ART'
+                  _              _
+  __ _  __ _ _ __| |_ ___   ___ | |
+ / _` |/ _` | '__| __/ _ \ / _ \| |
+| (_| | (_| | |  | || (_) | (_) | |
+ \__,_|\__,_|_|   \__\___/ \___/|_|
+ART
+      ;;
+  esac
+  printf '%s' "$RESET"
+  # ASCII separator: this line prints on the fallback path too, where a
+  # middle dot would be exactly the glyph the fallback exists to avoid.
+  printf ' %sv%s%s  |  audit, plan, apply, prove\n\n' "$BOLD" "$AARTOOL_VERSION" "$RESET"
+}
 
+usage() {
+  banner
+  cat <<'EOF'
 Usage:
   aartool <command> [options]
 

--- a/scripts/aartool-src/main.sh
+++ b/scripts/aartool-src/main.sh
@@ -61,10 +61,49 @@ vrun() {
   "$@"
 }
 
-usage() {
-  cat <<'EOF'
-aartool: CyberAar hardening toolkit
+# The banner prints on the human-facing paths only: a bare invocation and
+# --help. Not on --version, which is parsed by scripts and by our own tests, and
+# not on every subcommand, where it would be noise in front of the output you
+# actually asked for.
+#
+# Two versions. The block one reads at any size and is what the published
+# screenshots show; the ASCII one is for a terminal that cannot render those
+# glyphs, which on the machines this tool is pointed at is not hypothetical: a
+# serial console on a hardened box, a rescue shell, a locale set to C. The
+# fallback is chosen from the locale rather than attempted and repaired, because
+# there is no way to un-print a line of boxes.
+banner() {
+  printf '%s' "$CYAN"
+  case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+    *UTF-8*|*utf8*|*UTF8*)
+      cat <<'ART'
+ █████╗  █████╗ ██████╗ ████████╗ ██████╗  ██████╗ ██╗
+██╔══██╗██╔══██╗██╔══██╗╚══██╔══╝██╔═══██╗██╔═══██╗██║
+███████║███████║██████╔╝   ██║   ██║   ██║██║   ██║██║
+██╔══██║██╔══██║██╔══██╗   ██║   ██║   ██║██║   ██║██║
+██║  ██║██║  ██║██║  ██║   ██║   ╚██████╔╝╚██████╔╝███████╗
+╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝    ╚═════╝  ╚═════╝ ╚══════╝
+ART
+      ;;
+    *)
+      cat <<'ART'
+                  _              _
+  __ _  __ _ _ __| |_ ___   ___ | |
+ / _` |/ _` | '__| __/ _ \ / _ \| |
+| (_| | (_| | |  | || (_) | (_) | |
+ \__,_|\__,_|_|   \__\___/ \___/|_|
+ART
+      ;;
+  esac
+  printf '%s' "$RESET"
+  # ASCII separator: this line prints on the fallback path too, where a
+  # middle dot would be exactly the glyph the fallback exists to avoid.
+  printf ' %sv%s%s  |  audit, plan, apply, prove\n\n' "$BOLD" "$AARTOOL_VERSION" "$RESET"
+}
 
+usage() {
+  banner
+  cat <<'EOF'
 Usage:
   aartool <command> [options]
 

--- a/scripts/tests/test_aartool.sh
+++ b/scripts/tests/test_aartool.sh
@@ -55,6 +55,26 @@ check_rc() {
 
 # ── Dispatch ─────────────────────────────────────────────────────────────────
 check    "version"          "$($AARTOOL --version 2>&1)"        "aartool"
+
+# The banner is for humans. --version is parsed, by scripts and by
+# test_versions.sh, so it must stay one line with a number on it.
+check_exact "version output is one line" "$($AARTOOL --version 2>&1 | wc -l)" "1"
+check    "banner on a bare invocation"   "$(LANG=C LC_ALL=C $AARTOOL 2>&1)"        "__ _  __ _ _ __"
+check    "banner on --help"              "$(LANG=C LC_ALL=C $AARTOOL --help 2>&1)" "__ _  __ _ _ __"
+check    "banner states the version"     "$($AARTOOL --help 2>&1)" "audit, plan, apply, prove"
+check    "block banner under UTF-8"      "$(LC_ALL=en_US.UTF-8 $AARTOOL --help 2>&1)" "█████"
+
+# The fallback exists for terminals that cannot render block glyphs. If any
+# non-ASCII survives on that path it defeats the whole point, and a line of
+# replacement boxes is not something you can un-print.
+_ascii_banner=$(LANG=C LC_ALL=C $AARTOOL --help 2>&1 | head -7)
+if LC_ALL=C grep -qP '[^\x00-\x7F]' <<<"$_ascii_banner"; then
+  FAIL=$((FAIL+1))
+  printf 'FAIL  the C-locale banner still contains non-ASCII, which is what it exists to avoid:\n%s\n' \
+    "$(LC_ALL=C grep -oP '[^\x00-\x7F]' <<<"$_ascii_banner" | sort -u | tr -d '\n')"
+else
+  PASS=$((PASS+1))
+fi
 check    "help lists plan"  "$($AARTOOL --help 2>&1)"           "plan"
 check_rc "no args exits 1"  1  "$AARTOOL"
 check    "unknown command"  "$($AARTOOL frobnicate 2>&1)"       "Unknown command"


### PR DESCRIPTION
## A CLI that never says its own name

`aartool --help` opened with `aartool: CyberAar hardening toolkit` and nothing else. A bare invocation opened with the usage block cold. The tool is the product, and the first thing it printed did not look like one.

Now both paths open with the name in block glyphs, the version, and the loop the tool exists for: `audit, plan, apply, prove`.

## Where it does not print, which is the part that took the thinking

- **Not on `--version`.** That output is parsed, by other scripts and by our own `test_versions.sh`. It stays one line with a number on it, and there is now a test asserting exactly that.
- **Not on subcommands.** A banner in front of `advise` output is noise ahead of the thing you asked for.
- **Not on error paths.** `aartool frobnicate` prints the error and nothing else.

So it prints where a human is reading and nowhere a machine is.

## The fallback is chosen, not repaired

Two forms: block glyphs, and an ASCII figlet fallback picked **from the locale** before anything is written.

That ordering is the whole point. There is no way to un-print a line of replacement boxes, so this cannot be a try-and-fix. And the machines this tool gets pointed at are exactly the ones where it matters: a serial console on a hardened box, a rescue shell, a locale set to `C`.

Colours ride the existing `[[ -t 1 ]]` guard, so a pipe gets no escape codes. Verified with `cat -v`, not by assumption.

## Guards

A test greps the C-locale banner for any non-ASCII and prints the offending codepoints if it finds them. That is the failure the fallback exists to prevent, so testing anything less would be testing that the feature is present rather than that it works.

`test_docs.sh` matters more than usual here: it checks every documented invocation against the CLI's own `--help`, which this change alters. It passes unmodified.

```
test_aartool 104 · test_docs 164 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 15 · test_escaping 14 · test_check_commands 11
809 assertions, 0 failed · generated bundle in sync with aartool-src/
```
