### PR TITLE
feat(packaging): a .deb and an .rpm, proven by installing them

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,83 @@
+---
+name: Packages
+
+# Builds the .deb and the .rpm, then INSTALLS them in the distributions they
+# target and uses them. Building is not the interesting part: aartool finds its
+# playbooks by walking up from its own file, so the package works only while
+# /usr/bin/aartool is a symlink into /usr/share/aartool. A copy builds, installs
+# and passes any check that only reads the file list, then fails on first use.
+#
+# On a tag, the packages are attached to the release.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packaging/**"
+      - "scripts/aartool"
+      - "scripts/cyberaar-baseline.sh"
+      - "scripts/run-hardening.sh"
+      - "ansible-hardening/**"
+      - "dashboard/**"
+      - ".github/workflows/packages.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "packaging/**"
+      - "scripts/aartool"
+      - "scripts/cyberaar-baseline.sh"
+      - "scripts/run-hardening.sh"
+      - "ansible-hardening/**"
+      - "dashboard/**"
+      - ".github/workflows/packages.yml"
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+
+  build:
+    name: Build and install-test
+    runs-on: ubuntu-latest
+    steps:
+      # The payload is staged with `git archive HEAD`, so the build needs real
+      # history rather than the default shallow checkout of a merge commit.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build the .deb and the .rpm
+        run: bash packaging/build.sh
+
+      - name: Install them in debian:12 and rockylinux:9 and use them
+        run: bash packaging/tests/install-test.sh
+
+      - name: Version guard
+        run: bash scripts/tests/test_versions.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: aartool-packages
+          path: |
+            packaging/dist/*.deb
+            packaging/dist/*.rpm
+            packaging/dist/SHA256SUMS
+          if-no-files-found: error
+
+  release:
+    name: Attach to release
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: aartool-packages
+          path: dist
+
+      - name: Upload to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber --repo "$GITHUB_REPOSITORY"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ __pycache__/
 # Local agent context. Stays on the machine: it carries working notes and
 # paths that are not useful to a contributor and should never reach the repo.
 CLAUDE.md
+
+# Package build artifacts
+packaging/dist/
+packaging/stage/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ supported by the role logic but has no Molecule image yet: treat it as untested.
 
 ## Install
 
+A `.deb` and an `.rpm` are attached to every [release](https://github.com/cyberaar/aartool/releases).
+Both are noarch and install the same payload:
+
+```bash
+# Debian, Ubuntu
+sudo apt install ./aartool_3.2.0_all.deb
+
+# RHEL, Rocky, AlmaLinux, Fedora
+sudo dnf install ./aartool-3.2.0-1.noarch.rpm
+```
+
+Ansible is a recommended dependency, not a required one: the audit half of the
+tool never calls it. Your inventory belongs at `/etc/aartool/inventory`, where
+an upgrade will not touch it. See [docs/PACKAGING.md](docs/PACKAGING.md) for the
+layout and the reasoning.
+
+From a clone, which is what you want if you intend to change anything:
+
 ```bash
 git clone https://github.com/cyberaar/aartool
 cd aartool

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -1,0 +1,100 @@
+# Packaging
+
+How the `.deb` and the `.rpm` are built, what they put where, and why.
+
+For installing aartool, see the Install section of the [README](../README.md).
+
+## Building
+
+```
+packaging/build.sh [OUTDIR]     # default: packaging/dist
+```
+
+nfpm runs in a container, so this needs no packaging toolchain on the machine
+and behaves the same here as in CI. One config, `packaging/nfpm.yaml`, produces
+both formats. There is nothing to compile: a hand-maintained `debian/rules` and
+a `.spec` describing the same noarch payload would drift apart, the way every
+other pair of literals in this repository eventually has.
+
+The version comes from `AARTOOL_VERSION` in `scripts/aartool-src/main.sh`, so a
+package cannot report a version the tool does not. `test_versions.sh` fails if
+anyone types a literal into `nfpm.yaml` instead.
+
+## The payload comes from git, not from your working copy
+
+`build.sh` stages with `git archive HEAD`. This is a safety property rather than
+tidiness:
+
+`ansible-hardening/inventory/hosts` is gitignored **because it names real
+machines**, and it exists in most working copies. Staging from the working tree
+would publish it to everyone who runs `apt install aartool`. `git archive`
+cannot see it, and the build additionally refuses to run if that file ever
+turns up in the payload.
+
+Build scaffolding, test scaffolding and the bundle sources are pruned. The
+sources stay on GitHub, which is where the GPL points people.
+
+## Layout
+
+| Path | What |
+|---|---|
+| `/usr/bin/aartool` | **symlink** to `/usr/share/aartool/scripts/aartool` |
+| `/usr/share/aartool/` | the payload: scripts, `ansible-hardening/`, dashboard |
+| `/usr/share/aartool/.packaged` | marker: tells aartool it was installed from a package |
+| `/etc/aartool/inventory` | your inventory. Not shipped, see below |
+| `/usr/share/doc/aartool/` | README, docs, LICENSE |
+
+### Why /usr/bin/aartool is a symlink
+
+aartool finds the playbooks, the baseline script and the dashboard by walking up
+from its own file until it sees `ansible-hardening/`. `resolve_paths` follows
+symlinks first, so the walk starts in `/usr/share/aartool` where those live.
+
+A **copy** in `/usr/bin` has nothing above it but `/usr` and `/`. It builds, it
+installs, it passes any check that only reads the file list, and then every
+command fails on first use. This is the same reason `aartool install` symlinks
+rather than copies, and `packaging/tests/install-test.sh` asserts it on both
+distributions.
+
+### Why the inventory lives in /etc
+
+Everything under `/usr/share` belongs to the package manager and is replaced
+wholesale on upgrade. An inventory written there would be destroyed by the next
+`apt upgrade` without a word. The `.packaged` marker sends `resolve_paths` to
+`/etc/aartool/inventory` instead; a git checkout is unaffected and still uses
+`ansible-hardening/inventory/hosts`.
+
+The inventory is **deliberately not shipped**. An inventory that arrives already
+populated is one somebody runs `apply` against by accident, and the dangerous
+mistake with `apply` has always been the wrong target rather than the wrong
+intent. Absent, aartool prints the same copy-the-example message it prints for a
+fresh clone.
+
+## Ansible is a weak dependency
+
+`Recommends:` on Debian, `Suggests:` on RPM. Not `Depends:`.
+
+`inspect`, `advise`, `explain`, `surface`, `report` and `diff` never invoke
+Ansible. A tool whose claim is that it runs on a constrained machine should not
+pull in the Ansible stack before it will tell you what is wrong with your
+`sshd_config`. `plan` and `apply` check for it themselves and say so, and
+`aartool doctor` reports it.
+
+Note that `apt` installs Recommends by default and `dnf` does not install
+Suggests, so a Debian user gets Ansible unless they ask not to, and a Fedora or
+RHEL user installs it when they need `plan` and `apply`. That asymmetry is the
+distributions' convention, not ours.
+
+## Testing
+
+```
+packaging/tests/install-test.sh
+```
+
+Installs both packages in `debian:12` and `rockylinux:9` and uses them: version,
+help, `explain --list`, `explain SSH-01`, the inventory path, and a real
+`inspect` run to completion.
+
+The probes run as a **non-root user** wherever they can. The first build of this
+package shipped mode `0640` throughout, so root could run it and nobody else
+could even read it, and root-only testing would have found nothing.

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Build the .deb and the .rpm.
+#
+# Usage: packaging/build.sh [OUTDIR]     (default: packaging/dist)
+#
+# The payload is staged with `git archive HEAD`, never copied from the working
+# tree. That is a safety property, not tidiness: ansible-hardening/inventory/
+# hosts is gitignored because it names real machines, and it is present in most
+# working copies. Copying the tree would publish it to anyone who runs
+# `apt install aartool`.
+#
+# nfpm runs in a container so this needs no packaging toolchain on the host and
+# behaves the same here as it does in CI.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$PWD"
+OUT="${1:-$ROOT/packaging/dist}"
+STAGE="$ROOT/packaging/stage"
+NFPM_IMAGE="goreleaser/nfpm:v2.43.0"
+
+VERSION="$(grep -oP '^AARTOOL_VERSION="\K[^"]+' scripts/aartool-src/main.sh)"
+[[ -n "$VERSION" ]] || { echo "cannot read AARTOOL_VERSION" >&2; exit 1; }
+
+echo "aartool $VERSION"
+
+# ── Stage ────────────────────────────────────────────────────────────────────
+rm -rf "$STAGE" "$OUT"
+mkdir -p "$STAGE" "$OUT"
+
+if ! git diff --quiet HEAD -- scripts/aartool; then
+  echo "WARNING: scripts/aartool differs from HEAD. The package is built from" >&2
+  echo "         HEAD, so your uncommitted bundle will NOT be in it." >&2
+fi
+
+git archive HEAD | tar -x -C "$STAGE"
+
+# Prune what a user does not need at runtime. Everything here is either build
+# scaffolding or test scaffolding; the sources stay on GitHub, which is where
+# the GPL points people anyway.
+rm -rf \
+  "$STAGE/ansible-hardening/molecule" \
+  "$STAGE/ansible-hardening/requirements-dev.txt" \
+  "$STAGE/scripts/tests" \
+  "$STAGE/scripts/src" \
+  "$STAGE/scripts/aartool-src" \
+  "$STAGE/scripts/build.sh" \
+  "$STAGE/scripts/build-aartool.sh" \
+  "$STAGE/execution-environment" \
+  "$STAGE/packaging" \
+  "$STAGE/.github" \
+  "$STAGE/CLAUDE.md"
+
+# The inventory must not be in the payload under any circumstances. git archive
+# already excludes it, so this is a second lock on the same door: if it is ever
+# committed by mistake, the build fails rather than shipping it.
+if [[ -e "$STAGE/ansible-hardening/inventory/hosts" ]]; then
+  echo "REFUSING TO BUILD: ansible-hardening/inventory/hosts is in the payload." >&2
+  echo "That file names real machines and is meant to be gitignored." >&2
+  exit 1
+fi
+
+# Tells resolve_paths that this is a packaged install, so it reads the
+# inventory from /etc/aartool rather than from under /usr/share.
+printf 'Installed from a distribution package. Inventory lives in /etc/aartool/inventory.\n' \
+  > "$STAGE/.packaged"
+
+# nfpm takes each file's mode from the stage, and a working copy carries
+# whatever the developer's umask produced. Here that was 0640 and 0750, which
+# packages a tool root can run and no other user can even read. Normalise:
+# everyone may read, directories stay traversable, and the executable bit is
+# preserved only where it already existed. Same fix, and the same reason, as
+# the chmod that follows an rsync into a webroot.
+chmod -R a+rX "$STAGE"
+
+# ── Build ────────────────────────────────────────────────────────────────────
+for pkg in deb rpm; do
+  docker run --rm \
+    -v "$ROOT/packaging:/work" \
+    -v "$OUT:/out" \
+    -w /work \
+    -e "AARTOOL_VERSION=$VERSION" \
+    "$NFPM_IMAGE" \
+    package --config /work/nfpm.yaml --packager "$pkg" --target /out
+done
+
+rm -rf "$STAGE"
+
+echo
+ls -1 "$OUT"
+( cd "$OUT" && sha256sum ./* > SHA256SUMS && cat SHA256SUMS )

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,90 @@
+# One description of the package, built into both a .deb and an .rpm.
+#
+# Written for nfpm rather than debian/rules plus a .spec because aartool is
+# shell and Ansible: there is nothing to compile, and two hand-maintained
+# packaging trees for one noarch payload would drift apart the way every other
+# pair of literals in this project has.
+#
+# Built by packaging/build.sh, which stages the payload from `git archive` so
+# only tracked files can reach a published package. That matters more here than
+# it looks: ansible-hardening/inventory/hosts is gitignored precisely because it
+# names real machines, and it exists in most working copies.
+
+name: aartool
+arch: all
+platform: linux
+version: ${AARTOOL_VERSION}
+section: admin
+priority: optional
+maintainer: CyberAar <contact@cyberaar.io>
+description: |
+  CIS hardening for Linux estates: audit, plan, apply, prove.
+  aartool audits a host against 109 checks, orders the findings by how
+  reachable they are rather than by severity, says what closing each one
+  costs, and can apply the fixes through the Ansible roles it ships.
+  It runs against a local machine or a remote estate over SSH, including
+  through a bastion, with no agent to install.
+vendor: CyberAar
+homepage: https://cyberaar.io
+license: GPL-3.0-or-later
+
+# Ansible is NOT a hard dependency. inspect, advise, explain, surface, report
+# and diff never invoke it, and a tool whose whole claim is that it runs on a
+# constrained machine should not drag in the Ansible stack before it will tell
+# you what is wrong with your sshd_config. plan and apply check for it
+# themselves and say so, and `aartool doctor` reports it.
+depends:
+  - bash
+recommends:
+  - ansible-core
+
+overrides:
+  rpm:
+    depends:
+      - bash
+    recommends:
+      - ansible-core
+  deb:
+    depends:
+      - bash
+    recommends:
+      - ansible-core
+
+contents:
+  # The payload. Staged and pruned by build.sh.
+  - src: ./stage/scripts
+    dst: /usr/share/aartool/scripts
+  - src: ./stage/ansible-hardening
+    dst: /usr/share/aartool/ansible-hardening
+  - src: ./stage/dashboard
+    dst: /usr/share/aartool/dashboard
+
+  # The marker that tells resolve_paths this is a packaged install, so the
+  # inventory is read from /etc rather than from under /usr/share.
+  - src: ./stage/.packaged
+    dst: /usr/share/aartool/.packaged
+
+  # A SYMLINK, not a copy. aartool finds the playbooks, the baseline script and
+  # the dashboard by walking up from its own file; resolve_paths follows the
+  # symlink first, so the walk starts in /usr/share/aartool where those live.
+  # A copied binary in /usr/bin would find none of them, which is the same
+  # reason `aartool install` symlinks.
+  - src: /usr/share/aartool/scripts/aartool
+    dst: /usr/bin/aartool
+    type: symlink
+
+  - src: ./stage/LICENSE
+    dst: /usr/share/doc/aartool/LICENSE
+  - src: ./stage/README.md
+    dst: /usr/share/doc/aartool/README.md
+  - src: ./stage/docs
+    dst: /usr/share/doc/aartool/docs
+
+  # Config directory. The inventory itself is deliberately NOT shipped: an
+  # inventory that arrives prepopulated is an inventory someone runs `apply`
+  # against by accident. Absent, require_inventory prints the copy-the-example
+  # message it already prints for a fresh clone.
+  - dst: /etc/aartool
+    type: dir
+    file_info:
+      mode: 0755

--- a/packaging/tests/install-test.sh
+++ b/packaging/tests/install-test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Install the built packages in the distributions they target, and use them.
+#
+# A package that builds is not a package that works. The failure this exists to
+# catch is specific: aartool locates the playbooks, the baseline script and the
+# dashboard by walking up from its own file, so /usr/bin/aartool has to be a
+# symlink into /usr/share/aartool. If that ever becomes a copy, every command
+# fails at run time while the package still builds, installs, and passes any
+# check that only reads the file list.
+#
+# The probes run as a NON-ROOT user wherever they can. The first build of this
+# package shipped mode 0640 throughout, and root could not tell the difference.
+#
+# Usage: packaging/tests/install-test.sh [DIST_DIR]
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+DIST="${1:-packaging/dist}"
+DEB="$(ls "$DIST"/aartool_*_all.deb 2>/dev/null | head -1)"
+RPM="$(ls "$DIST"/aartool-*.noarch.rpm 2>/dev/null | head -1)"
+[[ -f "$DEB" ]] || { echo "no .deb in $DIST. Run packaging/build.sh first." >&2; exit 1; }
+[[ -f "$RPM" ]] || { echo "no .rpm in $DIST. Run packaging/build.sh first." >&2; exit 1; }
+
+PASS=0; FAIL=0
+
+PROBE='
+set -e
+U=tester
+useradd -m "$U" 2>/dev/null || true
+
+echo "on PATH:            $(command -v aartool)"
+test -L /usr/bin/aartool && echo "symlink:            yes (not a copy)"
+echo "version:            $(su -s /bin/bash "$U" -c "aartool --version")"
+su -s /bin/bash "$U" -c "aartool --help" >/dev/null && echo "help as non-root:   readable"
+echo "checks found:       $(su -s /bin/bash "$U" -c "aartool explain --list" | wc -l)"
+su -s /bin/bash "$U" -c "aartool explain SSH-01" >/dev/null && echo "explain SSH-01:     resolved"
+su -s /bin/bash "$U" -c "aartool plan --target linux_servers" 2>&1 \
+  | grep -q "/etc/aartool/inventory" && echo "inventory path:     /etc/aartool/inventory"
+test -f /usr/share/aartool/ansible-hardening/inventory/hosts.example \
+  && echo "example inventory:  present"
+aartool inspect --no-save >/dev/null && echo "inspect:            ran to completion"
+echo "roles shipped:      $(ls /usr/share/aartool/ansible-hardening/roles | wc -l)"
+test -f /usr/share/aartool/dashboard/index.html && echo "dashboard:          present"
+'
+
+run_case() {
+  local name="$1" image="$2" install="$3" out rc
+  echo "=== $name ==="
+  out=$(docker run --rm -v "$PWD/$DIST:/pkg:ro" "$image" bash -c "set -e; $install; $PROBE" 2>&1)
+  rc=$?
+  echo "$out" | sed 's/^/    /'
+  if [[ $rc -eq 0 ]]; then PASS=$((PASS+1)); echo "    -> PASS"
+  else FAIL=$((FAIL+1)); echo "    -> FAIL (exit $rc)"; fi
+  echo
+}
+
+run_case "debian:12 (apt)" debian:12 \
+  "apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq /pkg/$(basename "$DEB") >/dev/null 2>&1"
+
+run_case "rockylinux:9 (dnf)" rockylinux:9 \
+  "dnf install -y -q /pkg/$(basename "$RPM") >/dev/null 2>&1"
+
+echo "$PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -216,7 +216,17 @@ resolve_paths() {
   ANSIBLE_BASE="$root/ansible-hardening"
   # Overridable so a run can point at another estate's inventory, and so the
   # tests can work against a fixture instead of whatever is on the machine.
-  INVENTORY="${AARTOOL_INVENTORY:-$ANSIBLE_BASE/inventory/hosts}"
+  #
+  # A packaged install keeps its inventory in /etc instead. Everything under
+  # /usr/share belongs to the package manager and is replaced wholesale on
+  # upgrade, so an inventory written there would be silently destroyed by the
+  # next `apt upgrade`. The marker file ships only in the .deb and the .rpm, so
+  # a git checkout behaves exactly as it always has.
+  if [[ -f "$root/.packaged" ]]; then
+    INVENTORY="${AARTOOL_INVENTORY:-/etc/aartool/inventory}"
+  else
+    INVENTORY="${AARTOOL_INVENTORY:-$ANSIBLE_BASE/inventory/hosts}"
+  fi
   INVENTORY_EXAMPLE="$ANSIBLE_BASE/inventory/hosts.example"
   TOOLKIT_DASHBOARD="$root/dashboard/index.html"
   BASELINE="$root/scripts/cyberaar-baseline.sh"

--- a/scripts/aartool-src/lib/paths.sh
+++ b/scripts/aartool-src/lib/paths.sh
@@ -51,7 +51,17 @@ resolve_paths() {
   ANSIBLE_BASE="$root/ansible-hardening"
   # Overridable so a run can point at another estate's inventory, and so the
   # tests can work against a fixture instead of whatever is on the machine.
-  INVENTORY="${AARTOOL_INVENTORY:-$ANSIBLE_BASE/inventory/hosts}"
+  #
+  # A packaged install keeps its inventory in /etc instead. Everything under
+  # /usr/share belongs to the package manager and is replaced wholesale on
+  # upgrade, so an inventory written there would be silently destroyed by the
+  # next `apt upgrade`. The marker file ships only in the .deb and the .rpm, so
+  # a git checkout behaves exactly as it always has.
+  if [[ -f "$root/.packaged" ]]; then
+    INVENTORY="${AARTOOL_INVENTORY:-/etc/aartool/inventory}"
+  else
+    INVENTORY="${AARTOOL_INVENTORY:-$ANSIBLE_BASE/inventory/hosts}"
+  fi
   INVENTORY_EXAMPLE="$ANSIBLE_BASE/inventory/hosts.example"
   TOOLKIT_DASHBOARD="$root/dashboard/index.html"
   BASELINE="$root/scripts/cyberaar-baseline.sh"

--- a/scripts/tests/test_docs.sh
+++ b/scripts/tests/test_docs.sh
@@ -78,7 +78,7 @@ done
 
 # The dedicated manual must exist and be linked from the README, or nobody
 # finds it.
-for d in AARTOOL ANSIBLE BASELINE DASHBOARD CONTAINER; do
+for d in AARTOOL ANSIBLE BASELINE DASHBOARD CONTAINER PACKAGING; do
   [[ -f "../docs/$d.md" ]] && ok || fail "docs/$d.md is missing"
   grep -q "docs/$d.md" ../README.md && ok || fail "README.md does not link to docs/$d.md"
 done

--- a/scripts/tests/test_versions.sh
+++ b/scripts/tests/test_versions.sh
@@ -111,5 +111,23 @@ eq "aartool --version output" "$got" "$AARTOOL_SRC"
 got=$(bash cyberaar-baseline.sh --help 2>/dev/null | grep -oP 'Baseline Checker v\K[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 eq "cyberaar-baseline.sh --help banner" "$got" "$BASELINE_SRC"
 
+# The package takes its version from AARTOOL_VERSION at build time, so a .deb
+# that reports a version the tool itself does not is impossible by
+# construction. Keep it impossible: a literal typed in here is exactly the
+# drift this file exists to prevent, and every user would see it in
+# `apt list aartool`.
+if grep -qF 'version: ${AARTOOL_VERSION}' ../packaging/nfpm.yaml; then
+  ok
+else
+  bad "packaging/nfpm.yaml does not take its version from \${AARTOOL_VERSION}"
+fi
+strays=$(grep -nP '^\s*version:\s*[0-9]+\.[0-9]+\.[0-9]+' ../packaging/nfpm.yaml || true)
+if [[ -z "$strays" ]]; then
+  ok
+else
+  bad "packaging/nfpm.yaml hardcodes a version:"
+  printf '%s\n' "$strays" | sed 's/^/        /'
+fi
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Step one of two

You asked for `apt install` / `dnf install`. That needs two things: packages, and a signed repository to serve them from. This is the packages. The repository at `pkgs.cyberaar.io` follows in a second PR, so this one can be reviewed on its own and there is something real to serve when it lands.

After this, a release carries a `.deb` and an `.rpm` that install cleanly on the distributions aartool targets.

## The interesting failure is not the build

aartool finds the playbooks, the baseline script and the dashboard by **walking up from its own file** until it sees `ansible-hardening/`. That is why `aartool install` has always made a symlink rather than a copy.

A package that puts a **copy** in `/usr/bin` builds fine, installs fine, and passes any check that only reads the file list. Then it fails on the first command a user runs:

```
[ERROR] Cannot find the toolkit. Looked for ansible-hardening/ in /usr/bin
        and six directories above it.
```

That is the injected-drift run, not a hypothetical. `/usr/bin/aartool` is a symlink into `/usr/share/aartool`, and `install-test.sh` asserts it on both distributions rather than trusting it.

## The inventory had to move

Everything under `/usr/share` belongs to the package manager and is replaced wholesale on upgrade. An inventory there is destroyed by the next `apt upgrade`, silently. So a packaged install reads `/etc/aartool/inventory`, selected by a marker file shipped only in the packages. A git checkout is untouched and still uses `ansible-hardening/inventory/hosts`.

The inventory is **deliberately not shipped**. One that arrives already populated is one somebody runs `apply` against by accident, and the dangerous mistake with `apply` has always been the wrong target, not the wrong intent. Absent, aartool prints the same copy-the-example message a fresh clone gets.

## The payload cannot contain your machines

`build.sh` stages with `git archive HEAD`, never from the working tree.

`ansible-hardening/inventory/hosts` is gitignored **because it names real machines**, and it is present in most working copies. Staging from the tree would publish it to everyone running `apt install aartool`. `git archive` cannot see it, and the build refuses outright if it ever appears in the payload anyway.

## Ansible is Recommends, not Depends

`inspect`, `advise`, `explain`, `surface`, `report` and `diff` never invoke Ansible. A tool whose claim is that it runs on a constrained machine should not pull in the Ansible stack before it will tell you what is wrong with your `sshd_config`. `plan` and `apply` check for it themselves; `doctor` reports it.

## Two defects found by testing, not by reading

**Every file shipped `0640` / `0750`.** The developer umask went straight into the package: root could run it, no other user could even read it. The probes run as an unprivileged user, which is the only reason this surfaced. Same failure family as the webroot chmod.

**`push_tags:` is not a GitHub Actions trigger.** I wrote it, it parsed as an unknown key and would have silently never fired. Release assets attach on `release: published`.

## Verified

```
debian:12 (apt)        PASS      rockylinux:9 (dnf)     PASS
  symlink not a copy               symlink not a copy
  runs as non-root                 runs as non-root
  109 checks, 52 roles             109 checks, 52 roles
  /etc/aartool/inventory           /etc/aartool/inventory
  real inspect completes           real inspect completes

test_aartool 104 · test_docs 168 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 11
815 assertions, 0 failed
```

`test_versions.sh` gains a guard: the package version comes from `AARTOOL_VERSION` at build time, and hardcoding a literal in `nfpm.yaml` now fails the suite. Proven by hardcoding `9.9.9` and watching it fail.

Package sizes: 468K deb, 552K rpm, both noarch.
