### PR TITLE
docs: lead with how this is tested, not with who typed it

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,8 +392,25 @@ or (at your option) any later version. See [LICENSE](LICENSE) for the full text.
 ## Contributors
 
 - [@Bantou96](https://github.com/Bantou96), Founder
-- [@moustaphisene](https://github.com/moustaphisene), Contributor (CIS gap coverage: sudo, cron, wireless hardening roles)
-- [Claude](https://claude.ai) (Anthropic), AI pair programmer
+- [@moustaphisene](https://github.com/moustaphisene), CIS gap coverage: sudo, cron, wireless hardening roles
+
+## How this is built and tested
+
+Written with AI assistance ([Claude](https://claude.ai), Anthropic), and tested
+harder because of it:
+
+- **815 assertions on every commit**, plus Molecule scenarios on Rocky 9 and
+  Ubuntu 22.04.
+- **Every guard here was proven to fail on injected drift before it was
+  trusted.** A check that cannot fail is worse than no check.
+- **Run against a live 14-node estate, not only in CI.** One live hardening run
+  found 4 defects that 716 assertions had missed, which is why it is still run
+  on real machines.
+- **The check and role counts in this README are derived from the tool itself**,
+  so the documentation cannot claim a number the code does not produce.
+
+If a claim in this README is not checked by a test, treat it as a bug and open
+an issue.
 
 ---
 


### PR DESCRIPTION
## The problem was placement, not disclosure

`## Contributors` listed an AI alongside two named people. That invites a reader to weigh **authorship** before they have seen anything about the work, and on a security tool the reflex is "AI-written security code". Meanwhile the evidence that should answer that reflex was buried further down the page.

## What changes

The disclosure stays. It moves into a section that leads with what the assistance was spent on:

```
## How this is built and tested

Written with AI assistance (Claude, Anthropic), and tested harder because of it:

- 815 assertions on every commit, plus Molecule on Rocky 9 and Ubuntu 22.04
- Every guard here was proven to fail on injected drift before it was trusted
- Run against a live 14-node estate, not only in CI. One live hardening run
  found 4 defects that 716 assertions had missed
- The check and role counts in this README are derived from the tool itself

If a claim in this README is not checked by a test, treat it as a bug and open
an issue.
```

That is **more** informative than "AI pair programmer", not less, and it puts the disclosure in service of the reason to trust the tool rather than in competition with it.

The closing line is an invitation to check the claims, which is the standard the rest of the repository already holds itself to.

```
test_aartool 104 · test_docs 168 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 11
815 assertions, 0 failed
```
