### PR TITLE
docs: commit the generator for the release-post image

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ each has its own document.
 | **`cyberaar-baseline.sh`** | The audit itself: one bash file, no dependencies, `curl`-able onto an air-gapped box | [docs/BASELINE.md](docs/BASELINE.md) |
 | **Dashboard** | Single HTML file, no server, no external requests, works on an isolated network | [docs/DASHBOARD.md](docs/DASHBOARD.md) |
 | **Container image** | Ansible and the collections already present, for running without installing anything | [docs/CONTAINER.md](docs/CONTAINER.md) |
+| **Packages** | `.deb` and `.rpm`, and the signed repository they are served from | [docs/PACKAGING.md](docs/PACKAGING.md) |
+| **Media** | Regenerating the terminal graphic used in release posts | [docs/MEDIA.md](docs/MEDIA.md) |
 
 ### Layout
 

--- a/docs/MEDIA.md
+++ b/docs/MEDIA.md
@@ -1,0 +1,45 @@
+# Media
+
+How to regenerate the terminal graphic used in release posts and announcements.
+
+```bash
+python3 scripts/make-help-image.py --out aartool-help.png
+```
+
+Needs Pillow and DejaVu Sans Mono:
+
+```bash
+pip install Pillow
+sudo apt install fonts-dejavu-core      # or: sudo dnf install dejavu-sans-mono-fonts
+```
+
+`--scale 2` is the default and gives a crisp 2200px image; `--scale 1` halves it.
+
+## Why it pipes from the tool
+
+The text comes from a real `aartool --help` run and is never retyped. An
+announcement image is the one artefact nobody re-checks after a release: it is
+posted once, then lives on other people's timelines. A version number typed by
+hand into a picture is wrong at the next release and nothing anywhere will fail.
+
+The same reasoning produced the guard on the aartool figures on cyberaar.io.
+That page had claimed 51 Ansible roles against a real 52, and 96 CIS controls
+against a real 109, for an unknown period.
+
+**Regenerate after every release**, before posting anything. The image carries
+the version and the command list, and both move.
+
+## Why PIL and not SVG
+
+An SVG would be the obvious choice for something this geometric, and it does
+not work here. Every SVG renderer tried substitutes a non-monospace font for the
+box-drawing glyphs in the banner, so the characters stop tiling and the
+letterforms turn to mush. Per-character grid placement and `textLength` with
+`lengthAdjust="spacingAndGlyphs"` were both tried; both still broke, because
+positioning cannot fix a glyph that is drawn wider than its cell.
+
+PIL renders the glyphs with the font's own metrics, so the banner tiles the way
+it does in a terminal.
+
+If you change this, check the banner at full size before believing it. The
+failure is obvious in the art and invisible in the code.

--- a/scripts/make-help-image.py
+++ b/scripts/make-help-image.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Render `aartool --help` as a terminal graphic, for release posts and README art.
+
+The text is piped from the real command and never retyped, so the picture cannot
+claim a version, a command or a count that the tool does not produce. That is
+the whole point: an announcement image is the one artefact nobody re-checks
+after a release, and a stale one is a public untruth.
+
+Drawn with PIL rather than SVG on purpose. Every SVG renderer tried here
+substitutes a non-monospace font for the box-drawing glyphs in the banner, and
+the letterforms stop tiling: per-character grid placement and forced glyph
+widths both still broke. PIL with DejaVu Sans Mono tiles correctly.
+
+Usage:
+  python3 scripts/make-help-image.py [--out FILE] [--scale N]
+
+Needs Pillow and DejaVu Sans Mono:
+  pip install Pillow
+  apt install fonts-dejavu-core     # or dnf install dejavu-sans-mono-fonts
+"""
+import argparse
+import os
+import subprocess
+import sys
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
+    sys.exit("Pillow is required: pip install Pillow")
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FONT_DIRS = [
+    "/usr/share/fonts/truetype/dejavu",          # Debian, Ubuntu
+    "/usr/share/fonts/dejavu-sans-mono-fonts",   # Fedora, RHEL
+    "/usr/share/fonts/dejavu",
+]
+BG, FG, ACC, DIM, HD, BAR = "#0d1117", "#c9d1d9", "#00e5b0", "#7d8590", "#f0f6fc", "#161b22"
+BANNER_ROWS = 6
+
+
+def find_font(name):
+    for d in FONT_DIRS:
+        p = os.path.join(d, name)
+        if os.path.exists(p):
+            return p
+    sys.exit(f"{name} not found. Install DejaVu Sans Mono, or the banner will not tile.")
+
+
+def help_lines():
+    """The real output, truncated at Global options. Truncating is honest;
+    inventing a line would not be."""
+    exe = os.path.join(ROOT, "scripts", "aartool")
+    out = subprocess.run([exe, "--help"], cwd=ROOT, capture_output=True, text=True,
+                         env={**os.environ, "LC_ALL": "C.UTF-8"})
+    if out.returncode != 0:
+        sys.exit(f"aartool --help failed:\n{out.stderr}")
+    lines = [l.rstrip() for l in out.stdout.split("\n")]
+    try:
+        lines = lines[:next(i for i, l in enumerate(lines) if l.startswith("Global options:"))]
+    except StopIteration:
+        sys.exit("could not find the Global options block; has --help changed shape?")
+    while lines and not lines[-1]:
+        lines.pop()
+    return lines
+
+
+def render(lines, scale):
+    fs, lh, pad = 22 * scale, 32 * scale, 45 * scale
+    reg = ImageFont.truetype(find_font("DejaVuSansMono.ttf"), fs)
+    bold = ImageFont.truetype(find_font("DejaVuSansMono-Bold.ttf"), fs)
+    small = ImageFont.truetype(find_font("DejaVuSansMono.ttf"), 17 * scale)
+    adv = reg.getlength("M")
+
+    top, w = 95 * scale, 1100 * scale
+    h = top + len(lines) * lh + 125 * scale
+
+    img = Image.new("RGB", (w, h), BG)
+    d = ImageDraw.Draw(img)
+
+    d.rectangle([0, 0, w, 52 * scale], fill=BAR)
+    for i, c in enumerate(("#ff5f57", "#febc2e", "#28c840")):
+        x = (28 + i * 26) * scale
+        d.ellipse([x, 18 * scale, x + 16 * scale, 34 * scale], fill=c)
+    title = "aartool --help"
+    d.text(((w - small.getlength(title)) / 2, 18 * scale), title, font=small, fill=DIM)
+
+    for n, line in enumerate(lines):
+        y = top + n * lh
+        if n < BANNER_ROWS:
+            d.text((pad, y), line, font=reg, fill=ACC)
+        elif line.strip().startswith("v") and "|" in line:
+            d.text((pad, y), line, font=bold, fill=HD)
+        elif line.endswith(":") and not line.startswith(" "):
+            d.text((pad, y), line, font=bold, fill=HD)
+        elif line.startswith("  ") and len(line) > 14 and line[2] != " ":
+            d.text((pad, y), line[:14], font=bold, fill=ACC)
+            d.text((pad + 14 * adv, y), line[14:], font=reg, fill=FG)
+        else:
+            d.text((pad, y), line, font=reg, fill=FG)
+
+    fy = top + len(lines) * lh + 30 * scale
+    d.line([pad, fy - 20 * scale, w - pad, fy - 20 * scale], fill="#30363d", width=scale)
+    d.text((pad, fy), "$ sudo apt install aartool", font=bold, fill=ACC)
+    d.text((pad, fy + 31 * scale), "$ sudo dnf install aartool", font=bold, fill=ACC)
+    tail = "pkgs.cyberaar.io  ·  GPL-3.0"
+    d.text((w - pad - small.getlength(tail), fy + 34 * scale), tail, font=small, fill=DIM)
+    return img
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", default="aartool-help.png", help="output PNG (default: %(default)s)")
+    ap.add_argument("--scale", type=int, default=2,
+                    help="pixel density, 2 gives a crisp image on retina (default: %(default)s)")
+    a = ap.parse_args()
+
+    lines = help_lines()
+    img = render(lines, a.scale)
+    img.save(a.out)
+    version = next((l.strip() for l in lines if l.strip().startswith("v")), "unknown version")
+    print(f"{a.out}  {img.width}x{img.height}  ({version})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_docs.sh
+++ b/scripts/tests/test_docs.sh
@@ -78,7 +78,7 @@ done
 
 # The dedicated manual must exist and be linked from the README, or nobody
 # finds it.
-for d in AARTOOL ANSIBLE BASELINE DASHBOARD CONTAINER PACKAGING; do
+for d in AARTOOL ANSIBLE BASELINE DASHBOARD CONTAINER PACKAGING MEDIA; do
   [[ -f "../docs/$d.md" ]] && ok || fail "docs/$d.md is missing"
   grep -q "docs/$d.md" ../README.md && ok || fail "README.md does not link to docs/$d.md"
 done


### PR DESCRIPTION
The 3.3.0 announcement image was produced by a script in a temporary directory, which makes it a one-off. The image carries the version and the command list, and both move every release.

## It pipes from the tool, never retypes

```bash
python3 scripts/make-help-image.py --out aartool-help.png
```

The text comes from a real `aartool --help` run, truncated at `Global options:`. Truncating is honest; inventing a line would not be.

An announcement image is the one artefact nobody re-checks after a release: posted once, then living on other people's timelines. A version typed by hand into a picture is wrong at the next release and **nothing anywhere fails**. That is exactly how cyberaar.io ended up claiming 51 Ansible roles against a real 52, and 96 CIS controls against a real 109.

## Why PIL and not SVG, documented because it looks wrong

An SVG is the obvious choice for something this geometric. It does not work.

Every SVG renderer tried substitutes a non-monospace font for the box-drawing glyphs, so the banner stops tiling and the letterforms turn to mush. Per-character grid placement and `textLength` with `lengthAdjust="spacingAndGlyphs"` were both tried, and both still broke: positioning cannot fix a glyph drawn wider than its cell. PIL uses the font's own metrics, so it tiles the way a terminal does.

`docs/MEDIA.md` records this so the next person does not spend the same hour rediscovering it.

## Guarded

`docs/MEDIA.md` joins the list `test_docs.sh` enforces, so it must exist and stay linked from the README. Proven by breaking it both ways:

```
delete docs/MEDIA.md          FAIL  docs/MEDIA.md is missing
                              FAIL  README.md links to 'docs/MEDIA.md', which does not exist
remove the README link        FAIL  README.md does not link to docs/MEDIA.md
restored                      172 passed, 0 failed
```

The layout table also gains the `PACKAGING` row it should have had when packaging landed.

```
test_aartool 104 · test_docs 172 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 11
819 assertions, 0 failed
```
