### PR TITLE
fix(docs): the documented apt install failed on any machine with a strict umask

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ From the package repository, which is what most people want:
 
 ```bash
 # Debian, Ubuntu
+sudo install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://pkgs.cyberaar.io/gpg | sudo tee /etc/apt/keyrings/aartool.asc >/dev/null
+sudo chmod a+r /etc/apt/keyrings/aartool.asc
 echo "deb [signed-by=/etc/apt/keyrings/aartool.asc] https://pkgs.cyberaar.io/deb stable main" \
   | sudo tee /etc/apt/sources.list.d/aartool.list
 sudo apt update && sudo apt install aartool
@@ -58,6 +60,11 @@ sudo apt update && sudo apt install aartool
 sudo curl -fsSL https://pkgs.cyberaar.io/aartool.repo -o /etc/yum.repos.d/aartool.repo
 sudo dnf install aartool
 ```
+
+The `chmod a+r` is not decoration. apt verifies signatures as the unprivileged
+`_apt` user, and `sudo tee` creates the file with your umask: on a machine set
+to `umask 027` that is mode 0640, `_apt` cannot read it, and apt fails with
+`Unknown error executing apt-key`, which names neither permissions nor the file.
 
 Both packages are signed, and so is the repository metadata. `apt upgrade` and
 `dnf upgrade` pick up new releases from then on.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -70,6 +70,35 @@ mistake with `apply` has always been the wrong target rather than the wrong
 intent. Absent, aartool prints the same copy-the-example message it prints for a
 fresh clone.
 
+## The keyring has to be world readable
+
+apt verifies signatures as the unprivileged `_apt` user, not as root. The
+documented install therefore ends with:
+
+```bash
+sudo chmod a+r /etc/apt/keyrings/aartool.asc
+```
+
+Without it, `curl ... | sudo tee` creates the file with the invoking user's
+umask. On a machine set to `umask 027` that is mode 0640, `_apt` cannot read it,
+and apt reports:
+
+```
+Err:6 https://pkgs.cyberaar.io/deb stable InRelease
+  Unknown error executing apt-key
+E: The repository ... is not signed.
+```
+
+which names neither permissions nor the file, and reads like a signing problem
+on our side rather than a local one.
+
+This was shipped and hit a real user. It survived testing because the container
+running the test was root with `umask 022`, so `tee` happened to produce 0644
+and the missing `chmod` never mattered. The install test now runs under
+`umask 027` for exactly this reason. It is the second time this machine's umask
+has produced a defect: the first packages built were 0640 throughout, readable
+only by root.
+
 ## Ansible is a weak dependency
 
 `Recommends:` on Debian, `Suggests:` on RPM. Not `Depends:`.


### PR DESCRIPTION
Reported by a user following the README on Ubuntu 24.04, hours after release.

## What happened

```
Err:6 https://pkgs.cyberaar.io/deb stable InRelease
  Unknown error executing apt-key
E: The repository 'https://pkgs.cyberaar.io/deb stable InRelease' is not signed.
```

The keyring was there and correct:

```
-rw-r----- 1 root root 1717 /etc/apt/keyrings/aartool.asc
```

**Mode 0640.** apt verifies signatures as the unprivileged `_apt` user, which cannot read a root-only file. `curl | sudo tee` creates the file with the invoking user's umask, and that machine runs `umask 027`.

The message names neither permissions nor the file, and reads like a signing problem at our end. A first-time user would reasonably conclude the repository is broken and stop there.

## The fix

```bash
sudo install -m 0755 -d /etc/apt/keyrings
curl -fsSL https://pkgs.cyberaar.io/gpg | sudo tee /etc/apt/keyrings/aartool.asc >/dev/null
sudo chmod a+r /etc/apt/keyrings/aartool.asc
```

Which is what every other third-party repository's instructions do, for exactly this reason. The README now says why, so nobody deletes the line as noise.

## Why the test did not catch it

This is the part worth keeping.

`test-pkg-repo.sh` exists to prove the documented install works, and it passed. It ran as root in a container with `umask 022`, where `tee` produces 0644 and the missing `chmod` cannot matter. **A test environment more permissive than the machines being documented for is not a test.**

The companion PR in aarsoc-infra runs that test under `umask 027` and uses the documented commands verbatim, including the `| tee` pipeline rather than `curl -o`. Proven by removing the `chmod` and watching it reproduce the user's exact error:

```
FAIL  apt update and install from the signed repository
  Unknown error executing apt-key
  E: The repository 'http://repo/deb stable InRelease' is not signed.
```

and passing with it restored.

## Second time for this umask

The first packages built were 0640 throughout, installable by root and unreadable by anyone else, from the same `umask 027` on the same build machine. Both defects are now documented in `docs/PACKAGING.md`.
