### PR TITLE
fix(reports): every audit ended with a command the reader could not run

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,7 @@
 - **Terminal output**: colour-coded PASS / WARN / FAIL results with a security score
 - **HTML report**: self-contained file suitable for sharing with management or auditors
 - **JSON report**: machine-readable output for SIEM integration or CI pipelines
-- **Ansible remediation plan**: targeted `ansible-playbook` commands for every failing check
+- **Remediation plan**: a targeted `aartool apply` command for every failing check
 
 The script requires no external dependencies beyond standard Linux utilities (`bash`, `ss`, `sysctl`, `stat`, `find`, `awk`) and runs in a single pass in under two minutes on a typical server.
 
@@ -140,31 +140,40 @@ For WARN / FAIL checks the remediation hint is shown on the next line.
 
 **Score** = `PASS / TOTAL × 100`. Colour thresholds: ≥ 80% green, ≥ 60% yellow, < 60% red.
 
-### Ansible remediation plan
+### Remediation plan
 
-After the score, the terminal prints a deduplicated list of `ansible-playbook` commands covering every FAIL and WARN check that has an Ansible mapping:
+After the score, the terminal prints a deduplicated `aartool apply` command
+covering every FAIL and WARN check that has an Ansible mapping:
 
 ```
-━━━  ANSIBLE REMEDIATION PLAN  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━  REMEDIATION  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Platform: (RHEL9 / AlmaLinux / Rocky)
-  Playbook: playbooks/2_configure_hardening.yml
 
   [01] Apply pending kernel updates          tags: updates,patching
        Role  : linux_dnf_automatic_rhel9
-       ansible-playbook -i inventory/hosts playbooks/2_configure_hardening.yml --tags updates,patching
+       aartool apply --target <host> --only updates,patching
 
   [02] Account lockout (faillock)            tags: auth,pam
        Role  : linux_authselect_rhel9
-       ansible-playbook -i inventory/hosts playbooks/2_configure_hardening.yml --tags auth,pam
+       aartool apply --target <host> --only auth,pam
 
-  ── Fix everything in one command: ───────────────────────────
-  ansible-playbook -i inventory/hosts playbooks/2_configure_hardening.yml \
-    --tags updates,patching,auth,pam,ssh,...
+  ── Everything above, in one command: ────────────────────────
+  aartool apply --target <host> --only updates,patching,auth,pam,...
 
-  💡 Add --check --diff for a dry run before applying.
-     Add -l <host_or_group> to target a specific server.
+     Preview first. It changes nothing:
+  aartool plan --target <host> --only updates,patching,auth,pam,...
+
+     <host> is a host or group in your inventory.
+     aartool advise orders these by what an attacker reaches first,
+     and says what each fix costs before you run it.
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
+
+It prints `aartool` commands rather than raw `ansible-playbook` ones on purpose.
+The playbook paths only resolve inside a git checkout, so on a package install
+the old command could not run at all. `apply` also requires `--target` and makes
+you type the target name back, and a bare `ansible-playbook` with no `-l`
+defaults to the entire inventory.
 
 If `--ansible-dir` is provided, the playbook path is resolved to that directory.
 

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -2202,10 +2202,11 @@ _ansible_terminal_plan() {
     return
   fi
 
-  local _inv="-i inventory/hosts"
-  [[ -n "$ANSIBLE_INVENTORY" ]] && _inv="-i ${ANSIBLE_INVENTORY}"
-  local _pb="playbooks/2_configure_hardening.yml"
-  [[ -n "$ANSIBLE_DIR" ]] && _pb="${ANSIBLE_DIR}/playbooks/2_configure_hardening.yml"
+  # The target is not known here: this script audits a machine, it does not read
+  # an inventory. A placeholder is honest; a path relative to a git checkout is
+  # not, and that is what used to be printed.
+  local _tgt="<host>"
+  [[ -n "$AARTOOL_TARGET" ]] && _tgt="$AARTOOL_TARGET"
 
   # Detect OS family for role name hint
   local _os_hint="(RHEL9 / Ubuntu — auto-detected per host)"
@@ -2214,9 +2215,8 @@ _ansible_terminal_plan() {
   grep -qi 'ubuntu\|debian' /etc/os-release 2>/dev/null && \
     _os_hint="(Ubuntu / Debian)"
 
-  printf "\n${BOLD}${CYAN}━━━  ANSIBLE REMEDIATION PLAN  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-  printf "  Platform: ${BOLD}%s${NC}\n" "$_os_hint"
-  printf "  Playbook: ${BOLD}%s${NC}\n\n" "$_pb"
+  printf "\n${BOLD}${CYAN}━━━  REMEDIATION  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+  printf "  Platform: ${BOLD}%s${NC}\n\n" "$_os_hint"
 
   local _idx=1
   local _all_tags=""
@@ -2229,8 +2229,8 @@ _ansible_terminal_plan() {
     printf "  ${YELLOW}[%02d]${NC} ${BOLD}%-42s${NC}  tags: ${CYAN}%s${NC}\n" \
       "$_idx" "$_desc" "$_tags"
     printf "       Role  : %s\n" "$_role_hint"
-    printf "       ${GREEN}ansible-playbook %s %s --tags %s${NC}\n\n" \
-      "$_inv" "$_pb" "$_tags"
+    printf "       ${GREEN}aartool apply --target %s --only %s${NC}\n\n" \
+      "$_tgt" "$_tags"
     # collect unique tags
     IFS=',' read -ra _t <<< "$_tags"
     for t in "${_t[@]}"; do
@@ -2239,11 +2239,15 @@ _ansible_terminal_plan() {
     (( _idx++ ))
   done
 
-  printf "  ${BOLD}── Fix everything in one command: ───────────────────────────────────────────${NC}\n"
-  printf "  ${GREEN}ansible-playbook %s %s --tags %s${NC}\n" \
-    "$_inv" "$_pb" "$_all_tags"
-  printf "\n  ${CYAN}💡 Add --check --diff for a dry run before applying.${NC}\n"
-  printf "  ${CYAN}   Add -l <host_or_group> to target a specific server.${NC}\n"
+  printf "  ${BOLD}── Everything above, in one command: ────────────────────────────────────────${NC}\n"
+  printf "  ${GREEN}aartool apply --target %s --only %s${NC}\n" \
+    "$_tgt" "$_all_tags"
+  printf "\n  ${CYAN}   Preview first. It changes nothing:${NC}\n"
+  printf "  ${GREEN}aartool plan --target %s --only %s${NC}\n" \
+    "$_tgt" "$_all_tags"
+  printf "\n  ${CYAN}   %s is a host or group in your inventory.${NC}\n" "$_tgt"
+  printf "  ${CYAN}   aartool advise orders these by what an attacker reaches first,${NC}\n"
+  printf "  ${CYAN}   and says what each fix costs before you run it.${NC}\n"
   printf "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n\n"
 }
 
@@ -2414,10 +2418,11 @@ _render_html() {
     html_plan_entries["$_tkey"]="$_entry"
   done
 
-  _inv_flag="inventory/hosts"
-  [[ -n "$ANSIBLE_INVENTORY" ]] && _inv_flag=$(html_escape "$ANSIBLE_INVENTORY")
-  _pb="playbooks/2_configure_hardening.yml"
-  [[ -n "$ANSIBLE_DIR" ]] && _pb="${ANSIBLE_DIR}/playbooks/2_configure_hardening.yml"
+  # See the note in terminal.sh: this script audits a machine and has no
+  # inventory, so the target is a placeholder rather than a path that only
+  # resolves inside a git checkout.
+  _tgt="&lt;host&gt;"
+  [[ -n "$AARTOOL_TARGET" ]] && _tgt=$(html_escape "$AARTOOL_TARGET")
 
   _all_tags_html=""
   for _tkey in $(echo "${!html_plan_entries[@]}" | tr ' ' '\n' | sort); do
@@ -2427,11 +2432,11 @@ _render_html() {
     ANSIBLE_PLAN_HTML+="<td class='plan-desc'><strong>$_desc</strong></td>"
     ANSIBLE_PLAN_HTML+="<td class='plan-role'><code>$_role_r</code><br><small>Ubuntu: <code>$_role_u</code></small></td>"
     ANSIBLE_PLAN_HTML+="<td class='plan-tags'><span class='tag-badge'>--tags $_tags</span></td>"
-    ANSIBLE_PLAN_HTML+="<td class='plan-cmd'><code>ansible-playbook -i $_inv_flag $_pb --tags $_tags</code></td>"
+    ANSIBLE_PLAN_HTML+="<td class='plan-cmd'><code>aartool apply --target $_tgt --only $_tags</code></td>"
     ANSIBLE_PLAN_HTML+="</tr>"
   done
   _all_tags_html=$(echo "$_all_tags_html" | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
-  ANSIBLE_CONSOLIDATED_CMD="ansible-playbook -i ${_inv_flag} ${_pb} --tags ${_all_tags_html}"
+  ANSIBLE_CONSOLIDATED_CMD="aartool apply --target ${_tgt} --only ${_all_tags_html}"
 
 # Values that come from the audited machine, not from this script. hostname and
 # PRETTY_NAME in /etc/os-release are both settable by root on the target, so on
@@ -3011,7 +3016,7 @@ ${HTML_ROWS}
         <th>Catégorie / Issue</th>
         <th>Rôle Ansible</th>
         <th>Tags</th>
-        <th>Commande ansible-playbook</th>
+        <th>Commande aartool</th>
       </tr>
     </thead>
     <tbody>

--- a/scripts/src/renderers/html.sh
+++ b/scripts/src/renderers/html.sh
@@ -70,10 +70,11 @@ _render_html() {
     html_plan_entries["$_tkey"]="$_entry"
   done
 
-  _inv_flag="inventory/hosts"
-  [[ -n "$ANSIBLE_INVENTORY" ]] && _inv_flag=$(html_escape "$ANSIBLE_INVENTORY")
-  _pb="playbooks/2_configure_hardening.yml"
-  [[ -n "$ANSIBLE_DIR" ]] && _pb="${ANSIBLE_DIR}/playbooks/2_configure_hardening.yml"
+  # See the note in terminal.sh: this script audits a machine and has no
+  # inventory, so the target is a placeholder rather than a path that only
+  # resolves inside a git checkout.
+  _tgt="&lt;host&gt;"
+  [[ -n "$AARTOOL_TARGET" ]] && _tgt=$(html_escape "$AARTOOL_TARGET")
 
   _all_tags_html=""
   for _tkey in $(echo "${!html_plan_entries[@]}" | tr ' ' '\n' | sort); do
@@ -83,11 +84,11 @@ _render_html() {
     ANSIBLE_PLAN_HTML+="<td class='plan-desc'><strong>$_desc</strong></td>"
     ANSIBLE_PLAN_HTML+="<td class='plan-role'><code>$_role_r</code><br><small>Ubuntu: <code>$_role_u</code></small></td>"
     ANSIBLE_PLAN_HTML+="<td class='plan-tags'><span class='tag-badge'>--tags $_tags</span></td>"
-    ANSIBLE_PLAN_HTML+="<td class='plan-cmd'><code>ansible-playbook -i $_inv_flag $_pb --tags $_tags</code></td>"
+    ANSIBLE_PLAN_HTML+="<td class='plan-cmd'><code>aartool apply --target $_tgt --only $_tags</code></td>"
     ANSIBLE_PLAN_HTML+="</tr>"
   done
   _all_tags_html=$(echo "$_all_tags_html" | tr ',' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
-  ANSIBLE_CONSOLIDATED_CMD="ansible-playbook -i ${_inv_flag} ${_pb} --tags ${_all_tags_html}"
+  ANSIBLE_CONSOLIDATED_CMD="aartool apply --target ${_tgt} --only ${_all_tags_html}"
 
 # Values that come from the audited machine, not from this script. hostname and
 # PRETTY_NAME in /etc/os-release are both settable by root on the target, so on
@@ -667,7 +668,7 @@ ${HTML_ROWS}
         <th>Catégorie / Issue</th>
         <th>Rôle Ansible</th>
         <th>Tags</th>
-        <th>Commande ansible-playbook</th>
+        <th>Commande aartool</th>
       </tr>
     </thead>
     <tbody>

--- a/scripts/src/renderers/terminal.sh
+++ b/scripts/src/renderers/terminal.sh
@@ -26,10 +26,11 @@ _ansible_terminal_plan() {
     return
   fi
 
-  local _inv="-i inventory/hosts"
-  [[ -n "$ANSIBLE_INVENTORY" ]] && _inv="-i ${ANSIBLE_INVENTORY}"
-  local _pb="playbooks/2_configure_hardening.yml"
-  [[ -n "$ANSIBLE_DIR" ]] && _pb="${ANSIBLE_DIR}/playbooks/2_configure_hardening.yml"
+  # The target is not known here: this script audits a machine, it does not read
+  # an inventory. A placeholder is honest; a path relative to a git checkout is
+  # not, and that is what used to be printed.
+  local _tgt="<host>"
+  [[ -n "$AARTOOL_TARGET" ]] && _tgt="$AARTOOL_TARGET"
 
   # Detect OS family for role name hint
   local _os_hint="(RHEL9 / Ubuntu — auto-detected per host)"
@@ -38,9 +39,8 @@ _ansible_terminal_plan() {
   grep -qi 'ubuntu\|debian' /etc/os-release 2>/dev/null && \
     _os_hint="(Ubuntu / Debian)"
 
-  printf "\n${BOLD}${CYAN}━━━  ANSIBLE REMEDIATION PLAN  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-  printf "  Platform: ${BOLD}%s${NC}\n" "$_os_hint"
-  printf "  Playbook: ${BOLD}%s${NC}\n\n" "$_pb"
+  printf "\n${BOLD}${CYAN}━━━  REMEDIATION  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+  printf "  Platform: ${BOLD}%s${NC}\n\n" "$_os_hint"
 
   local _idx=1
   local _all_tags=""
@@ -53,8 +53,8 @@ _ansible_terminal_plan() {
     printf "  ${YELLOW}[%02d]${NC} ${BOLD}%-42s${NC}  tags: ${CYAN}%s${NC}\n" \
       "$_idx" "$_desc" "$_tags"
     printf "       Role  : %s\n" "$_role_hint"
-    printf "       ${GREEN}ansible-playbook %s %s --tags %s${NC}\n\n" \
-      "$_inv" "$_pb" "$_tags"
+    printf "       ${GREEN}aartool apply --target %s --only %s${NC}\n\n" \
+      "$_tgt" "$_tags"
     # collect unique tags
     IFS=',' read -ra _t <<< "$_tags"
     for t in "${_t[@]}"; do
@@ -63,11 +63,15 @@ _ansible_terminal_plan() {
     (( _idx++ ))
   done
 
-  printf "  ${BOLD}── Fix everything in one command: ───────────────────────────────────────────${NC}\n"
-  printf "  ${GREEN}ansible-playbook %s %s --tags %s${NC}\n" \
-    "$_inv" "$_pb" "$_all_tags"
-  printf "\n  ${CYAN}💡 Add --check --diff for a dry run before applying.${NC}\n"
-  printf "  ${CYAN}   Add -l <host_or_group> to target a specific server.${NC}\n"
+  printf "  ${BOLD}── Everything above, in one command: ────────────────────────────────────────${NC}\n"
+  printf "  ${GREEN}aartool apply --target %s --only %s${NC}\n" \
+    "$_tgt" "$_all_tags"
+  printf "\n  ${CYAN}   Preview first. It changes nothing:${NC}\n"
+  printf "  ${GREEN}aartool plan --target %s --only %s${NC}\n" \
+    "$_tgt" "$_all_tags"
+  printf "\n  ${CYAN}   %s is a host or group in your inventory.${NC}\n" "$_tgt"
+  printf "  ${CYAN}   aartool advise orders these by what an attacker reaches first,${NC}\n"
+  printf "  ${CYAN}   and says what each fix costs before you run it.${NC}\n"
   printf "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n\n"
 }
 

--- a/scripts/tests/test_check_commands.sh
+++ b/scripts/tests/test_check_commands.sh
@@ -78,5 +78,35 @@ for branch in 'dnf|dnf5|yum' 'apt-get' 'zypper'; do
   fi
 done
 
+# ── The remediation a report prints must be runnable ─────────────────────────
+#
+# The report renderers used to print
+#   ansible-playbook -i inventory/hosts playbooks/2_configure_hardening.yml ...
+# which resolves only inside a git checkout. On a package install the playbooks
+# are under /usr/share/aartool and that command cannot work, so every audit
+# ended with a remediation step the reader could not run.
+#
+# It is also the command aartool exists to replace: `apply` requires --target
+# and makes the operator type the target name back, because the dangerous
+# mistake is the wrong target, not the wrong intent. A raw ansible-playbook line
+# with no -l defaults to the whole inventory and teaches the reader around every
+# one of those guards.
+#
+# This is the second time this file has been wrong in this way: PR #94 removed
+# twelve references to a nonexistent inventory/hosts.yml, three of them here.
+for r in src/renderers/terminal.sh src/renderers/html.sh; do
+  name=$(basename "$r")
+  if grep -q 'ansible-playbook' "$r"; then
+    bad "$name prints a raw ansible-playbook command; reports must remediate through aartool"
+  else
+    ok
+  fi
+  if grep -q 'aartool apply --target' "$r"; then
+    ok
+  else
+    bad "$name no longer prints an 'aartool apply --target' command"
+  fi
+done
+
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Reported from a package install: the audit ran fine, and the one line telling the reader what to do next could not.

## What it printed

```
── Fix everything in one command: ──────────────────────────
ansible-playbook -i inventory/hosts playbooks/2_configure_hardening.yml --tags system,auth,...
```

Those paths resolve only inside a git checkout. On a package install the playbooks are under `/usr/share/aartool`, there is no `inventory/` in the working directory, and the command fails immediately.

## It also taught the reader around every guard

This is the command `aartool` exists to replace.

`apply` requires `--target` and makes the operator type the target name back, because **the dangerous mistake is the wrong target, not the wrong intent**. A bare `ansible-playbook` with no `-l` defaults to the entire inventory, and the old output offered `-l` as an afterthought below the command it had already given.

So the audit was quietly recommending the unguarded path.

## Now

```
  [01] SSH hardening                               tags: ssh
       Role  : ssh_hardening_ubuntu
       aartool apply --target <host> --only ssh

  ── Everything above, in one command: ────────────────────────
  aartool apply --target <host> --only ssh,firewall,kernel,sysctl

     Preview first. It changes nothing:
  aartool plan --target <host> --only ssh,firewall,kernel,sysctl

     <host> is a host or group in your inventory.
     aartool advise orders these by what an attacker reaches first,
     and says what each fix costs before you run it.
```

That is real output from the renderer, matching what `advise` already prints. `plan` comes second but is described first, because it changes nothing.

The target is a placeholder on purpose: this script audits a machine, it does not read an inventory. A placeholder is honest where a checkout-relative path was not.

The HTML report had the identical problem, including a `Commande ansible-playbook` column header. That is what gets emailed to a client.

## Guarded, because this is the second time

`test_check_commands.sh` now asserts the renderers contain no `ansible-playbook` and do contain `aartool apply --target`. Proven by reintroducing the old command:

```
FAIL  terminal.sh prints a raw ansible-playbook command; reports must remediate through aartool
FAIL  terminal.sh no longer prints an 'aartool apply --target' command
```

PR #94 already removed twelve references to a nonexistent `inventory/hosts.yml`, three of them in these same renderers. Nothing stopped it coming back. Now something does.

`scripts/README.md` documented the old block verbatim and is updated with it.

```
test_aartool 104 · test_docs 172 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
823 assertions, 0 failed
```
