### PR TITLE
release: 3.3.1, localhost as a target and an uninstall that exists

### DIFF
--- a/ansible-hardening/CHANGELOG.md
+++ b/ansible-hardening/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1]: 2026-08-26
+
+### Fixed
+
+- **Every audit ended with a command the reader could not run.** The
+  remediation block printed `ansible-playbook -i inventory/hosts
+  playbooks/...`, whose paths resolve only inside a git checkout. On a package
+  install the playbooks are under `/usr/share/aartool` and that command fails
+  immediately. Both the terminal and HTML reports now print
+  `aartool apply --target <host> --only TAGS`, which is also the guarded path:
+  `apply` requires a target and makes you type its name back, while a bare
+  `ansible-playbook` with no `-l` defaults to the whole inventory.
+- **The documented apt install failed on any machine with a strict umask.**
+  `curl | sudo tee` created the keyring with the caller's umask; at `umask 027`
+  that is mode 0640, and apt verifies as the unprivileged `_apt` user, which
+  cannot read it. It failed with `Unknown error executing apt-key`, naming
+  neither permissions nor the file. The instructions now `chmod a+r` the key.
+
+### Added
+
+- **`--target localhost`** for `plan` and `apply`: harden the machine you are
+  on, with no inventory and nothing over SSH. This is the machine `inspect`
+  just audited, and until now hardening it required an inventory entry, which a
+  package install has no way to create. Both commands say up front that
+  localhost needs root, rather than failing inside Ansible with "Premature end
+  of stream waiting for become success".
+- **`aartool uninstall`**, which previously reported itself as an unknown
+  command while the same thing existed behind `install --uninstall`. On a
+  packaged install it refuses and points at `apt remove` or `dnf remove`:
+  deleting the symlink would leave the package registered and its command
+  missing, which no later `apt install` would repair.
+
 ## [3.3.0]: 2026-08-25
 
 ### Added

--- a/ansible-hardening/galaxy.yml
+++ b/ansible-hardening/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: cyberaar
 name: hardening
-version: 3.3.0
+version: 3.3.1
 readme: README.md
 
 authors:

--- a/docs/AARTOOL.md
+++ b/docs/AARTOOL.md
@@ -318,12 +318,30 @@ Turn an audit into an ordered plan.
 
 | option | meaning |
 |---|---|
-| `-t, --target HOST\|GROUP` | Required. Must exist in the inventory |
+| `-t, --target HOST\|GROUP` | Required. Must exist in the inventory, or be `localhost` |
 | `-u, --user USER` | SSH user. Default `ansible` |
 | `--only TAGS` | Comma-separated role tags: `ssh`, `kernel`, `auth`, `firewall`, ... |
 | `--full` | Run the three-step pipeline: audit, harden, audit |
 | `-K, --ask-become-pass` | Prompt for the sudo password on the target |
 | `-y, --yes` | `apply` only. Skip the typed confirmation. For automation, and the flag to think about before you use it |
+
+**`--target localhost` hardens the machine you are on**, which is the machine
+`inspect` just audited:
+
+```bash
+sudo aartool plan  --target localhost      # changes nothing
+sudo aartool apply --target localhost
+```
+
+It needs no inventory and nothing goes over SSH: aartool writes a one-line
+inventory with `ansible_connection=local` for the run and removes it afterwards.
+That matters on a package install, where the playbooks live under `/usr/share`
+and there is nowhere writable to keep an inventory.
+
+Both commands need root for localhost, and both say so up front rather than
+failing inside Ansible. `plan` needs it too: it changes nothing, but it still
+reads `sshd_config`, audit rules and sysctls to work out what it *would*
+change. Use `sudo`, or `-K` to be asked for the password.
 
 ### `surface`
 
@@ -403,12 +421,26 @@ because `ansible-playbook` failing halfway with "couldn't resolve module
 ansible.posix.sysctl" tells an operator nothing about `ansible-galaxy`, and a
 half-applied hardening run is expensive.
 
-### `install`
+### `install` / `uninstall`
 
 | option | meaning |
 |---|---|
 | `--prefix DIR` | Install into `DIR/bin` instead of `/usr/local/bin` |
 | `--uninstall` | Remove the symlink |
+
+`aartool uninstall` is the same thing as `aartool install --uninstall`.
+
+On an install that came from a `.deb` or an `.rpm`, both refuse and point at the
+package manager:
+
+```bash
+sudo apt remove aartool       # Debian, Ubuntu
+sudo dnf remove aartool       # RHEL, Rocky, AlmaLinux, Fedora
+```
+
+Deleting `/usr/bin/aartool` by hand would leave the package registered as
+installed with its command missing, and no later `apt install` would repair
+that, because apt already believes the package is present.
 
 ---
 

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="3.3.0"
+AARTOOL_VERSION="3.3.1"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -121,6 +121,7 @@ Commands:
   report      Visualise audit reports, or bake them into one shareable file.
   diff        What changed between two audits. Exits non-zero on a regression.
   install     Put aartool on your PATH.
+  uninstall   Remove the symlink install created.
 
 Global options:
   -h, --help        Show this help, or help for a command
@@ -1816,6 +1817,8 @@ Usage:
 
 Options:
   -t, --target HOST|GROUP   Host or inventory group. Required.
+                            Use 'localhost' for this machine: no inventory
+                            needed, and nothing goes over SSH.
   -u, --user USER           SSH user (default: ansible)
       --ssh-key FILE        SSH private key. inspect has always taken one;
                             plan and apply did not, so on an estate with a
@@ -1863,10 +1866,33 @@ cmd_harden() {
   [[ -n "$target" ]] || die "--target is required. Name a host or an inventory group, e.g. 'aartool ${mode} --target web-01'."
 
   resolve_paths
-  require_inventory
 
-  if ! target_in_inventory "$target"; then
-    die "'$target' is not a host or group in $INVENTORY. Add it there first, or check the spelling."
+  # localhost is the one target that needs no inventory: it is the machine you
+  # are already on, which is also the machine `inspect` just audited. Requiring
+  # an inventory entry to harden it made the obvious first thing anyone tries
+  # fail on a package install, where there is no inventory at all and nowhere
+  # writable to put one.
+  #
+  # The temporary inventory carries ansible_connection=local, so nothing is
+  # attempted over SSH. Without it Ansible would try to ssh to "localhost",
+  # which needs a key and a running sshd for no reason.
+  local _local_inv=""
+  if [[ "$target" == "localhost" || "$target" == "127.0.0.1" ]]; then
+    target="localhost"
+    _local_inv="$(mktemp)"
+    printf 'localhost ansible_connection=local ansible_python_interpreter=%s\n' \
+      "$(command -v python3 || echo /usr/bin/python3)" > "$_local_inv"
+    export AARTOOL_INVENTORY="$_local_inv"
+    INVENTORY="$_local_inv"
+    # shellcheck disable=SC2064
+    trap "rm -f '$_local_inv'" RETURN
+  else
+    require_inventory
+    if ! target_in_inventory "$target"; then
+      die "'$target' is not a host or group in $INVENTORY. Add it there first, or check the spelling.
+        To harden the machine you are on instead, no inventory needed:
+          aartool ${mode} --target localhost"
+    fi
   fi
 
   local -a args=(-t "$target" -s "$( [[ "$full" == true ]] && echo all || echo 2 )")
@@ -1899,6 +1925,25 @@ cmd_harden() {
     read -r answer
     [[ "$answer" == "$target" ]] || die "Confirmation did not match. Nothing was changed."
     echo
+  fi
+
+  # Both modes need root on localhost, and plan needs it for a reason that is
+  # not obvious: it changes nothing, but the playbook still reads sshd_config,
+  # audit rules and sysctls to decide what it WOULD change. Without this the
+  # first thing anyone tries fails with "Premature end of stream waiting for
+  # become success", which names neither sudo nor the fix.
+  if [[ -n "$_local_inv" && "$EUID" -ne 0 && "$become" == false ]]; then
+    if [[ "$mode" == plan ]]; then
+      die "Previewing localhost needs root: the playbook reads sshd_config, audit
+        rules and sysctls to work out what it would change. It changes nothing.
+          sudo aartool plan --target localhost
+        Or be asked for the sudo password instead:
+          aartool plan --target localhost -K"
+    fi
+    die "Applying to localhost changes this machine and needs root.
+          sudo aartool apply --target localhost
+        Or be asked for the sudo password instead:
+          aartool apply --target localhost -K"
   fi
 
   info "Running $(basename "$HARDEN")"
@@ -3155,6 +3200,20 @@ cmd_install() {
 
   local bindir="$prefix/bin" link="$prefix/bin/aartool"
 
+  # A packaged install is owned by dpkg or rpm. Deleting /usr/bin/aartool here
+  # would leave the package registered as installed with its command missing,
+  # which no later `apt install` would repair because apt already believes the
+  # package is present. The package manager has to be the one to remove it.
+  if [[ "$uninstall" == true ]]; then
+    local _root; _root="$(_find_up "ansible-hardening" "$(_self_dir)" 2>/dev/null || true)"
+    if [[ -n "$_root" && -f "$_root/.packaged" ]]; then
+      die "aartool was installed from a package, so remove it with the package manager:
+          sudo apt remove aartool       # Debian, Ubuntu
+          sudo dnf remove aartool       # RHEL, Rocky, AlmaLinux, Fedora
+        Deleting the symlink here would leave the package installed and broken."
+    fi
+  fi
+
   if [[ "$uninstall" == true ]]; then
     if [[ -L "$link" || -e "$link" ]]; then
       rm -f "$link" || die "Cannot remove $link. Try with sudo."
@@ -3219,6 +3278,9 @@ main() {
     report)         shift; cmd_report "$@" ;;
     diff)           shift; cmd_diff "$@" ;;
     install)        shift; cmd_install "$@" ;;
+    # `aartool uninstall` is what people type. It used to be an unknown command,
+    # which is a poor answer when the thing they want exists behind a flag.
+    uninstall)      shift; cmd_install --uninstall "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/aartool-src/cmd/harden.sh
+++ b/scripts/aartool-src/cmd/harden.sh
@@ -16,6 +16,8 @@ Usage:
 
 Options:
   -t, --target HOST|GROUP   Host or inventory group. Required.
+                            Use 'localhost' for this machine: no inventory
+                            needed, and nothing goes over SSH.
   -u, --user USER           SSH user (default: ansible)
       --ssh-key FILE        SSH private key. inspect has always taken one;
                             plan and apply did not, so on an estate with a
@@ -63,10 +65,33 @@ cmd_harden() {
   [[ -n "$target" ]] || die "--target is required. Name a host or an inventory group, e.g. 'aartool ${mode} --target web-01'."
 
   resolve_paths
-  require_inventory
 
-  if ! target_in_inventory "$target"; then
-    die "'$target' is not a host or group in $INVENTORY. Add it there first, or check the spelling."
+  # localhost is the one target that needs no inventory: it is the machine you
+  # are already on, which is also the machine `inspect` just audited. Requiring
+  # an inventory entry to harden it made the obvious first thing anyone tries
+  # fail on a package install, where there is no inventory at all and nowhere
+  # writable to put one.
+  #
+  # The temporary inventory carries ansible_connection=local, so nothing is
+  # attempted over SSH. Without it Ansible would try to ssh to "localhost",
+  # which needs a key and a running sshd for no reason.
+  local _local_inv=""
+  if [[ "$target" == "localhost" || "$target" == "127.0.0.1" ]]; then
+    target="localhost"
+    _local_inv="$(mktemp)"
+    printf 'localhost ansible_connection=local ansible_python_interpreter=%s\n' \
+      "$(command -v python3 || echo /usr/bin/python3)" > "$_local_inv"
+    export AARTOOL_INVENTORY="$_local_inv"
+    INVENTORY="$_local_inv"
+    # shellcheck disable=SC2064
+    trap "rm -f '$_local_inv'" RETURN
+  else
+    require_inventory
+    if ! target_in_inventory "$target"; then
+      die "'$target' is not a host or group in $INVENTORY. Add it there first, or check the spelling.
+        To harden the machine you are on instead, no inventory needed:
+          aartool ${mode} --target localhost"
+    fi
   fi
 
   local -a args=(-t "$target" -s "$( [[ "$full" == true ]] && echo all || echo 2 )")
@@ -99,6 +124,25 @@ cmd_harden() {
     read -r answer
     [[ "$answer" == "$target" ]] || die "Confirmation did not match. Nothing was changed."
     echo
+  fi
+
+  # Both modes need root on localhost, and plan needs it for a reason that is
+  # not obvious: it changes nothing, but the playbook still reads sshd_config,
+  # audit rules and sysctls to decide what it WOULD change. Without this the
+  # first thing anyone tries fails with "Premature end of stream waiting for
+  # become success", which names neither sudo nor the fix.
+  if [[ -n "$_local_inv" && "$EUID" -ne 0 && "$become" == false ]]; then
+    if [[ "$mode" == plan ]]; then
+      die "Previewing localhost needs root: the playbook reads sshd_config, audit
+        rules and sysctls to work out what it would change. It changes nothing.
+          sudo aartool plan --target localhost
+        Or be asked for the sudo password instead:
+          aartool plan --target localhost -K"
+    fi
+    die "Applying to localhost changes this machine and needs root.
+          sudo aartool apply --target localhost
+        Or be asked for the sudo password instead:
+          aartool apply --target localhost -K"
   fi
 
   info "Running $(basename "$HARDEN")"

--- a/scripts/aartool-src/cmd/install.sh
+++ b/scripts/aartool-src/cmd/install.sh
@@ -50,6 +50,20 @@ cmd_install() {
 
   local bindir="$prefix/bin" link="$prefix/bin/aartool"
 
+  # A packaged install is owned by dpkg or rpm. Deleting /usr/bin/aartool here
+  # would leave the package registered as installed with its command missing,
+  # which no later `apt install` would repair because apt already believes the
+  # package is present. The package manager has to be the one to remove it.
+  if [[ "$uninstall" == true ]]; then
+    local _root; _root="$(_find_up "ansible-hardening" "$(_self_dir)" 2>/dev/null || true)"
+    if [[ -n "$_root" && -f "$_root/.packaged" ]]; then
+      die "aartool was installed from a package, so remove it with the package manager:
+          sudo apt remove aartool       # Debian, Ubuntu
+          sudo dnf remove aartool       # RHEL, Rocky, AlmaLinux, Fedora
+        Deleting the symlink here would leave the package installed and broken."
+    fi
+  fi
+
   if [[ "$uninstall" == true ]]; then
     if [[ -L "$link" || -e "$link" ]]; then
       rm -f "$link" || die "Cannot remove $link. Try with sudo."

--- a/scripts/aartool-src/main.sh
+++ b/scripts/aartool-src/main.sh
@@ -30,7 +30,7 @@
 # =============================================================================
 set -euo pipefail
 
-AARTOOL_VERSION="3.3.0"
+AARTOOL_VERSION="3.3.1"
 
 # ── Output ───────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
@@ -121,6 +121,7 @@ Commands:
   report      Visualise audit reports, or bake them into one shareable file.
   diff        What changed between two audits. Exits non-zero on a regression.
   install     Put aartool on your PATH.
+  uninstall   Remove the symlink install created.
 
 Global options:
   -h, --help        Show this help, or help for a command

--- a/scripts/aartool-src/run.sh
+++ b/scripts/aartool-src/run.sh
@@ -27,6 +27,9 @@ main() {
     report)         shift; cmd_report "$@" ;;
     diff)           shift; cmd_diff "$@" ;;
     install)        shift; cmd_install "$@" ;;
+    # `aartool uninstall` is what people type. It used to be an unknown command,
+    # which is a poor answer when the thing they want exists behind a flag.
+    uninstall)      shift; cmd_install --uninstall "$@" ;;
     -h|--help|help) usage ;;
     -V|--version|version) printf 'aartool %s\n' "$AARTOOL_VERSION" ;;
     # Named so the error can be specific rather than "unknown command".

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -17,7 +17,7 @@
 # =============================================================================
 
 SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
-SCRIPT_VERSION="4.6.0"
+SCRIPT_VERSION="4.6.1"
 SCRIPT_NAME="cyberaar-baseline"
 
 _show_help() {

--- a/scripts/run-hardening.sh
+++ b/scripts/run-hardening.sh
@@ -108,7 +108,12 @@ fi
 [[ -n "$ANSIBLE_BASE" ]] \
   || die "Cannot find ansible-hardening/ (looked 6 levels up from script location)."
 
-INVENTORY="$ANSIBLE_BASE/inventory/hosts"
+# AARTOOL_INVENTORY lets a caller point the run at another inventory. aartool
+# uses it for `--target localhost`, where it writes a one-line inventory to a
+# temporary file: a packaged install has $ANSIBLE_BASE under /usr/share, which
+# is read-only and replaced on upgrade, so there is nowhere there to put one.
+# Same variable the aartool side already honours.
+INVENTORY="${AARTOOL_INVENTORY:-$ANSIBLE_BASE/inventory/hosts}"
 PLAYBOOK_1="$ANSIBLE_BASE/playbooks/1_execute_baseline_before.yml"
 PLAYBOOK_2="$ANSIBLE_BASE/playbooks/2_configure_hardening.yml"
 PLAYBOOK_3="$ANSIBLE_BASE/playbooks/3_execute_baseline_after.yml"

--- a/scripts/src/main.sh
+++ b/scripts/src/main.sh
@@ -17,7 +17,7 @@
 # =============================================================================
 
 SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
-SCRIPT_VERSION="4.6.0"
+SCRIPT_VERSION="4.6.1"
 SCRIPT_NAME="cyberaar-baseline"
 
 _show_help() {

--- a/scripts/tests/test_aartool.sh
+++ b/scripts/tests/test_aartool.sh
@@ -76,6 +76,23 @@ else
   PASS=$((PASS+1))
 fi
 check    "help lists plan"  "$($AARTOOL --help 2>&1)"           "plan"
+
+# `aartool uninstall` used to be an unknown command while the thing it names
+# existed behind `install --uninstall`. Telling someone their verb does not
+# exist, when it does, is the worst of both answers.
+check    "uninstall is a command"    "$($AARTOOL --help 2>&1)"            "uninstall"
+check    "uninstall reaches install" "$($AARTOOL uninstall --help 2>&1)"  "aartool install"
+
+# localhost is the machine inspect just audited, and it needs no inventory.
+# Before this, hardening the obvious first target failed on a package install,
+# where there is no inventory and nowhere writable to put one.
+check    "plan documents localhost"  "$($AARTOOL plan --help 2>&1)"       "localhost"
+check    "apply documents localhost" "$($AARTOOL apply --help 2>&1)"      "localhost"
+
+# A wrong target should name the escape hatch rather than only the failure.
+check    "bad target suggests localhost" \
+         "$(AARTOOL_INVENTORY=$PWD/../ansible-hardening/inventory/hosts.example $AARTOOL plan --target nope 2>&1)" \
+         "--target localhost"
 check_rc "no args exits 1"  1  "$AARTOOL"
 check    "unknown command"  "$($AARTOOL frobnicate 2>&1)"       "Unknown command"
 check    "audit points to inspect" "$($AARTOOL audit 2>&1)"     "aartool inspect"


### PR DESCRIPTION
Both gaps found the same way: by installing the package and using it.

## `--target localhost`

```bash
sudo aartool plan  --target localhost      # changes nothing
sudo aartool apply --target localhost
```

The machine you are on is the machine `inspect` just audited, and until now hardening it required an inventory entry. A package install has no inventory and nowhere writable to make one: the playbooks live under `/usr/share`.

aartool writes a one-line inventory with `ansible_connection=local` for the run and removes it afterwards, so nothing is attempted over SSH. `run-hardening.sh` now honours `AARTOOL_INVENTORY` (the variable the aartool side already used) instead of computing the path unconditionally.

**Both commands check for root up front.** `plan` needs it too, which is not obvious: it changes nothing, but it still reads `sshd_config`, audit rules and sysctls to decide what it *would* change. Without the check, the first thing anyone tries fails with:

```
Premature end of stream waiting for become success
sudo: a password is required
```

which names neither sudo nor the fix. Now:

```
[ERROR] Previewing localhost needs root: the playbook reads sshd_config, audit
        rules and sysctls to work out what it would change. It changes nothing.
          sudo aartool plan --target localhost
```

A wrong target also names the escape hatch now, rather than only the failure.

## `aartool uninstall`

It existed only as `install --uninstall`, so typing the obvious verb returned `Unknown command: uninstall`. Telling someone their verb does not exist, when the thing does, is the worst of both answers.

On a packaged install it refuses:

```
[ERROR] aartool was installed from a package, so remove it with the package manager:
          sudo apt remove aartool
          sudo dnf remove aartool
        Deleting the symlink here would leave the package installed and broken.
```

Removing `/usr/bin/aartool` by hand leaves the package registered as installed with its command gone, and no later `apt install` repairs that, because apt already believes it is present. Verified by creating the `.packaged` marker and running it.

## Also in this release

The two fixes from earlier today: reports printing an `ansible-playbook` command no packaged user could run (#125), and the apt install failing on any machine with a strict umask (#124).

## Versions

| | 3.3.0 | 3.3.1 |
|---|---|---|
| `galaxy.yml` | 3.3.0 | **3.3.1** |
| `AARTOOL_VERSION` | 3.3.0 | **3.3.1** |
| `SCRIPT_VERSION` (own lineage) | 4.6.0 | **4.6.1** |

```
test_aartool 109 · test_docs 176 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
832 assertions, 0 failed
```
