### PR TITLE
docs: put localhost and uninstall in the README, not only the manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ tool never calls it. Your inventory belongs at `/etc/aartool/inventory`, where
 an upgrade will not touch it. See [docs/PACKAGING.md](docs/PACKAGING.md) for the
 layout and the reasoning.
 
+To remove it:
+
+```bash
+sudo apt remove aartool       # or: sudo dnf remove aartool
+```
+
 From a clone, which is what you want if you intend to change anything:
 
 ```bash
@@ -85,6 +91,7 @@ git clone https://github.com/cyberaar/aartool
 cd aartool
 sudo scripts/aartool install              # symlink into /usr/local/bin
 aartool doctor                            # is everything it needs actually here?
+sudo aartool uninstall                    # removes the symlink, keeps the clone
 ```
 
 Without root, or without installing at all:
@@ -188,6 +195,14 @@ aartool plan  --target web-01 --user ubuntu --only ssh
 aartool apply --target web-01 --user ubuntu --only ssh
 ```
 
+To harden the machine you are on, which is the machine step 1 just audited, use
+`localhost`. It needs no inventory and nothing goes over SSH:
+
+```bash
+sudo aartool plan  --target localhost --only ssh   # changes nothing
+sudo aartool apply --target localhost --only ssh
+```
+
 `apply` asks you to type the target name back. `--target` is required and is
 checked against the inventory first: the dangerous mistake is not "did I mean
 to run this", it is "did I mean this host or that group".
@@ -220,6 +235,7 @@ to filter the mail.
 | `report` | Bake reports into one self-contained HTML file, or serve the dashboard. |
 | `diff` | What changed between two audits. |
 | `install` | Put `aartool` on your PATH. |
+| `uninstall` | Remove it again. On a packaged install it points you at `apt remove` instead. |
 
 Add `-v` to any command to see what it is shelling out to. That is the flag
 that helps when the failure is in `ssh` or `ansible` rather than in `aartool`.


### PR DESCRIPTION
Both shipped in 3.3.1 and were documented in `docs/AARTOOL.md`, which is the right place for the full reference and the wrong place to *discover* that a command exists. The README is what a visitor reads, and neither appeared in it.

## Step 4 of the loop

```bash
aartool plan  --target web-01 --user ubuntu --only ssh
aartool apply --target web-01 --user ubuntu --only ssh
```

now followed by:

> To harden the machine you are on, which is the machine step 1 just audited, use `localhost`. It needs no inventory and nothing goes over SSH:

```bash
sudo aartool plan  --target localhost --only ssh   # changes nothing
sudo aartool apply --target localhost --only ssh
```

It sits beside the remote form rather than in a footnote, because it is the machine `inspect` just audited and therefore the first target most readers want.

## The commands table

```
| `uninstall` | Remove it again. On a packaged install it points you at `apt remove` instead. |
```

## Removal was documented nowhere

The install section now says how to remove the package, and the clone section shows `aartool uninstall` on the line after `aartool install`:

```bash
sudo scripts/aartool install              # symlink into /usr/local/bin
aartool doctor                            # is everything it needs actually here?
sudo aartool uninstall                    # removes the symlink, keeps the clone
```

## Checked, not just written

`test_docs.sh` went from **176 to 183 assertions**: it validates every `aartool` invocation in a fenced block against the CLI's own `--help`, so each new example is verified to be a real command with real flags rather than a plausible-looking one.

```
test_aartool 109 · test_docs 183 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
839 assertions, 0 failed
```
