### PR TITLE
feat(doctor): say when another aartool is ahead on PATH

### DIFF
--- a/scripts/aartool
+++ b/scripts/aartool
@@ -2583,6 +2583,47 @@ cmd_doctor() {
   printf '\n%saartool doctor%s\n' "$BOLD" "$RESET"
   printf '%s\n' "────────────────────────────────────────────────────────────────────"
 
+  # ── Which aartool is actually running ──────────────────────────────────────
+  #
+  # `aartool install` symlinks into /usr/local/bin, which precedes /usr/bin on
+  # every default PATH. Install the package afterwards and the old symlink wins
+  # silently: you get the clone's version, with none of the newer commands, and
+  # nothing says so. The symptom is a documented flag reported as unknown, and
+  # the reasonable conclusion is that the tool is broken rather than shadowed.
+  #
+  # Reported by someone whose --target localhost failed on 3.3.1 because a
+  # 3.2.0 clone symlink was ahead of the package.
+  local _running _first _other
+  _running="$(_self_dir)/$(basename "${BASH_SOURCE[0]}")"
+  [[ -f "$_running" ]] || _running="$(_self_dir)/aartool"
+  _running="$(readlink -f "$_running" 2>/dev/null || printf '%s' "$_running")"
+
+  _first="$(command -v aartool 2>/dev/null || true)"
+  if [[ -n "$_first" ]]; then
+    _first="$(readlink -f "$_first" 2>/dev/null || printf '%s' "$_first")"
+    if [[ "$_first" != "$_running" ]]; then
+      _doc_warn "another aartool is ahead on PATH" "$(command -v aartool)" \
+        "That one runs when you type 'aartool'. This one is $_running"
+    else
+      _doc_pass "aartool on PATH" "$_first"
+    fi
+  fi
+
+  # A packaged install being shadowed is worth naming outright, because the fix
+  # is to delete one symlink and there is no way to guess that.
+  #
+  # The comparison is against what typing 'aartool' resolves to, NOT against the
+  # file currently executing. Running a checkout copy directly is normal during
+  # development and shadows nothing. Getting that wrong made this check advise
+  # `sudo rm /usr/bin/aartool`, which is the package's own binary: the one file
+  # here that must never be deleted by hand.
+  if [[ -f /usr/share/aartool/.packaged && -n "$_first" && "$_first" != /usr/share/aartool/* ]]; then
+    local _pkgver=""
+    [[ -x /usr/bin/aartool ]] && _pkgver="$(/usr/bin/aartool --version 2>/dev/null || true)"
+    _doc_warn "packaged aartool is shadowed" "${_pkgver:-installed} at /usr/bin/aartool" \
+      "Typing 'aartool' runs $(command -v aartool) instead. Remove it: sudo rm $(command -v aartool)"
+  fi
+
   # ── The toolkit itself ─────────────────────────────────────────────────────
   _doc_pass "toolkit located" "$ANSIBLE_BASE"
   [[ -r "$BASELINE" ]] && _doc_pass "cyberaar-baseline.sh" "readable" \

--- a/scripts/aartool-src/cmd/doctor.sh
+++ b/scripts/aartool-src/cmd/doctor.sh
@@ -55,6 +55,47 @@ cmd_doctor() {
   printf '\n%saartool doctor%s\n' "$BOLD" "$RESET"
   printf '%s\n' "────────────────────────────────────────────────────────────────────"
 
+  # ── Which aartool is actually running ──────────────────────────────────────
+  #
+  # `aartool install` symlinks into /usr/local/bin, which precedes /usr/bin on
+  # every default PATH. Install the package afterwards and the old symlink wins
+  # silently: you get the clone's version, with none of the newer commands, and
+  # nothing says so. The symptom is a documented flag reported as unknown, and
+  # the reasonable conclusion is that the tool is broken rather than shadowed.
+  #
+  # Reported by someone whose --target localhost failed on 3.3.1 because a
+  # 3.2.0 clone symlink was ahead of the package.
+  local _running _first _other
+  _running="$(_self_dir)/$(basename "${BASH_SOURCE[0]}")"
+  [[ -f "$_running" ]] || _running="$(_self_dir)/aartool"
+  _running="$(readlink -f "$_running" 2>/dev/null || printf '%s' "$_running")"
+
+  _first="$(command -v aartool 2>/dev/null || true)"
+  if [[ -n "$_first" ]]; then
+    _first="$(readlink -f "$_first" 2>/dev/null || printf '%s' "$_first")"
+    if [[ "$_first" != "$_running" ]]; then
+      _doc_warn "another aartool is ahead on PATH" "$(command -v aartool)" \
+        "That one runs when you type 'aartool'. This one is $_running"
+    else
+      _doc_pass "aartool on PATH" "$_first"
+    fi
+  fi
+
+  # A packaged install being shadowed is worth naming outright, because the fix
+  # is to delete one symlink and there is no way to guess that.
+  #
+  # The comparison is against what typing 'aartool' resolves to, NOT against the
+  # file currently executing. Running a checkout copy directly is normal during
+  # development and shadows nothing. Getting that wrong made this check advise
+  # `sudo rm /usr/bin/aartool`, which is the package's own binary: the one file
+  # here that must never be deleted by hand.
+  if [[ -f /usr/share/aartool/.packaged && -n "$_first" && "$_first" != /usr/share/aartool/* ]]; then
+    local _pkgver=""
+    [[ -x /usr/bin/aartool ]] && _pkgver="$(/usr/bin/aartool --version 2>/dev/null || true)"
+    _doc_warn "packaged aartool is shadowed" "${_pkgver:-installed} at /usr/bin/aartool" \
+      "Typing 'aartool' runs $(command -v aartool) instead. Remove it: sudo rm $(command -v aartool)"
+  fi
+
   # ── The toolkit itself ─────────────────────────────────────────────────────
   _doc_pass "toolkit located" "$ANSIBLE_BASE"
   [[ -r "$BASELINE" ]] && _doc_pass "cyberaar-baseline.sh" "readable" \


### PR DESCRIPTION
`--target localhost` was reported as not working on a machine with 3.3.1 installed. The feature was fine. The machine was running 3.2.0.

```
/usr/local/bin/aartool -> /home/dell/aartool/scripts/aartool   (clone, 3.2.0)
/usr/bin/aartool                                                (package, 3.3.1)

aartool --version  ->  3.2.0
```

`aartool install` symlinks into `/usr/local/bin`, which precedes `/usr/bin` on every default PATH. Install the package afterwards and the old symlink keeps winning, **silently**.

The symptom is a documented flag reported as unknown, or a documented target rejected. The reasonable conclusion from that is "the tool is broken", not "my PATH has two of these".

## What doctor says now

```
!  another aartool is ahead on PATH   /usr/local/bin/aartool
   note That one runs when you type 'aartool'. This one is /home/dell/cfall/cyberaar-toolkit/scripts/aartool
!  packaged aartool is shadowed       aartool 3.3.1 at /usr/bin/aartool
   note Typing 'aartool' runs /usr/local/bin/aartool instead. Remove it: sudo rm /usr/local/bin/aartool
```

## A bug in the check, found by running it

The first version compared against **the file currently executing** rather than what `command -v aartool` resolves to. Running a checkout copy directly is normal during development and shadows nothing, so it fired a false warning, and worse, the advice it printed was:

```
Remove the symlink that shadows it: sudo rm /usr/bin/aartool
```

That is the package's own binary. Deleting it leaves the package registered as installed with its command gone, which is the exact failure `uninstall` was taught to refuse in 3.3.1. A check that recommends the most destructive available action is worse than no check.

It now compares `command -v aartool`, so `/usr/bin/aartool` resolves into `/usr/share/aartool/` and correctly does not warn.

## Verified both ways

- Package first on PATH: no shadow warning.
- Clone symlink placed in front of it: warns, and names the correct file to delete.

```
test_aartool 109 · test_docs 183 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
839 assertions, 0 failed
```
