### PR TITLE
fix(packaging): plan and apply were broken in every package

### DIFF
--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -99,6 +99,48 @@ and the missing `chmod` never mattered. The install test now runs under
 has produced a defect: the first packages built were 0640 throughout, readable
 only by root.
 
+## Symlinks inside a packaged directory are dropped
+
+`ansible-hardening/playbooks/roles` is a symlink to `../roles`, and it is what
+lets Ansible resolve the roles from a playbook one directory down.
+
+**nfpm does not carry symlinks it finds inside a directory tree.** It copied the
+four playbooks and dropped the link without a word, so every package shipped
+playbooks referencing roles nothing could find:
+
+```
+ERROR! the role 'linux_kernel_hardening_rhel9' was not found in
+  /usr/share/aartool/ansible-hardening/playbooks/roles:...
+```
+
+`plan` and `apply` failed at parse time in 3.3.0 and 3.3.1 while `inspect`,
+`advise` and `explain` all worked, so the package looked fine. The link is now
+declared explicitly as a `type: symlink` entry, and `run-hardening.sh` also
+exports `ANSIBLE_ROLES_PATH`, because the one path without which nothing runs
+should not depend on a symlink surviving a packaging step.
+
+The install test now runs `ansible-playbook --syntax-check` against the
+installed playbook, which is the step that was failing. Counting the shipped
+roles would not have caught it: the count was right.
+
+## The collections are not vendored
+
+The roles call `ansible.posix` (sysctl, firewalld, selinux, seboolean) and
+`community.general` (ufw). Neither is in the package:
+
+```bash
+ansible-galaxy collection install -r /usr/share/aartool/ansible-hardening/requirements.yml
+```
+
+`community.general` alone is **29 MB against a 480 KB package**, and this tool
+is aimed at machines with constrained bandwidth. Ansible itself is already only
+a recommended dependency for the same reason.
+
+`plan` and `apply` check for them before starting and print that command.
+Without the check, Ansible fails with `couldn't resolve module/action
+'ansible.posix.selinux'` pointing at a line inside a role, which reads like a
+bug in the role rather than a missing dependency on the machine.
+
 ## Ansible is a weak dependency
 
 `Recommends:` on Debian, `Suggests:` on RPM. Not `Depends:`.

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -59,6 +59,18 @@ contents:
   - src: ./stage/dashboard
     dst: /usr/share/aartool/dashboard
 
+  # ansible-hardening/playbooks/roles is a symlink to ../roles in the repository,
+  # and it is what lets Ansible resolve the roles from a playbook one directory
+  # down. nfpm does NOT carry symlinks found inside a directory tree: it copied
+  # the four playbooks and dropped the link without a word, so every packaged
+  # install had playbooks that referenced roles nothing could find, and `plan`
+  # and `apply` failed at parse time while everything else worked.
+  #
+  # Declaring it explicitly is the only way nfpm will ship it.
+  - src: ../roles
+    dst: /usr/share/aartool/ansible-hardening/playbooks/roles
+    type: symlink
+
   # The marker that tells resolve_paths this is a packaged install, so the
   # inventory is read from /etc rather than from under /usr/share.
   - src: ./stage/.packaged

--- a/packaging/tests/install-test.sh
+++ b/packaging/tests/install-test.sh
@@ -40,6 +40,30 @@ test -f /usr/share/aartool/ansible-hardening/inventory/hosts.example \
   && echo "example inventory:  present"
 aartool inspect --no-save >/dev/null && echo "inspect:            ran to completion"
 echo "roles shipped:      $(ls /usr/share/aartool/ansible-hardening/roles | wc -l)"
+
+# Shipping the roles is not the same as Ansible being able to FIND them.
+# playbooks/roles is a symlink to ../roles in the repository, and nfpm dropped
+# it silently when packaging the directory: every package had playbooks that
+# referenced roles nothing could resolve, so plan and apply failed at parse time
+# while inspect, advise and explain all worked. Counting files would not have
+# caught it, because the count was right.
+#
+# --syntax-check resolves roles, which is exactly the step that was failing.
+test -e /usr/share/aartool/ansible-hardening/playbooks/roles && echo "roles symlink:      present"
+if command -v ansible-playbook >/dev/null 2>&1; then
+  # The documented dependency step. The roles call ansible.posix and
+  # community.general, which are deliberately not vendored: community.general
+  # alone is 29 MB against a 480 KB package.
+  ansible-galaxy collection install -r \
+    /usr/share/aartool/ansible-hardening/requirements.yml >/dev/null 2>&1
+  ansible-playbook --syntax-check \
+    -i localhost, \
+    /usr/share/aartool/ansible-hardening/playbooks/2_configure_hardening.yml >/dev/null
+  echo "playbook parses:    roles and collections resolve"
+else
+  echo "playbook parses:    SKIPPED, ansible-core not installed" >&2
+  exit 1
+fi
 test -f /usr/share/aartool/dashboard/index.html && echo "dashboard:          present"
 '
 

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -1946,6 +1946,29 @@ cmd_harden() {
           aartool apply --target localhost -K"
   fi
 
+  # The roles call ansible.posix (sysctl, firewalld, selinux) and
+  # community.general (ufw). Without them Ansible fails at parse time with
+  # "couldn't resolve module/action 'ansible.posix.selinux'", pointing at a line
+  # inside a role, which reads like a bug in the role rather than a missing
+  # dependency on this machine. Say it here, with the command that fixes it.
+  #
+  # They are not vendored into the package on purpose: community.general alone
+  # is 29 MB against a 480 KB package, and this tool is aimed at machines with
+  # constrained bandwidth.
+  if command -v ansible-galaxy >/dev/null 2>&1; then
+    local _missing=() _c
+    for _c in ansible.posix community.general; do
+      ansible-galaxy collection list 2>/dev/null | grep -q "^${_c} " || _missing+=("$_c")
+    done
+    if [[ ${#_missing[@]} -gt 0 ]]; then
+      die "Missing Ansible collection(s): ${_missing[*]}
+        The hardening roles use them for sysctl, firewalld, selinux and ufw.
+        Install them:
+          ansible-galaxy collection install -r $ANSIBLE_BASE/requirements.yml
+        Then check everything at once with: aartool doctor"
+    fi
+  fi
+
   info "Running $(basename "$HARDEN")"
   bash "$HARDEN" "${args[@]}"
 }

--- a/scripts/aartool-src/cmd/harden.sh
+++ b/scripts/aartool-src/cmd/harden.sh
@@ -145,6 +145,29 @@ cmd_harden() {
           aartool apply --target localhost -K"
   fi
 
+  # The roles call ansible.posix (sysctl, firewalld, selinux) and
+  # community.general (ufw). Without them Ansible fails at parse time with
+  # "couldn't resolve module/action 'ansible.posix.selinux'", pointing at a line
+  # inside a role, which reads like a bug in the role rather than a missing
+  # dependency on this machine. Say it here, with the command that fixes it.
+  #
+  # They are not vendored into the package on purpose: community.general alone
+  # is 29 MB against a 480 KB package, and this tool is aimed at machines with
+  # constrained bandwidth.
+  if command -v ansible-galaxy >/dev/null 2>&1; then
+    local _missing=() _c
+    for _c in ansible.posix community.general; do
+      ansible-galaxy collection list 2>/dev/null | grep -q "^${_c} " || _missing+=("$_c")
+    done
+    if [[ ${#_missing[@]} -gt 0 ]]; then
+      die "Missing Ansible collection(s): ${_missing[*]}
+        The hardening roles use them for sysctl, firewalld, selinux and ufw.
+        Install them:
+          ansible-galaxy collection install -r $ANSIBLE_BASE/requirements.yml
+        Then check everything at once with: aartool doctor"
+    fi
+  fi
+
   info "Running $(basename "$HARDEN")"
   bash "$HARDEN" "${args[@]}"
 }

--- a/scripts/run-hardening.sh
+++ b/scripts/run-hardening.sh
@@ -114,6 +114,12 @@ fi
 # is read-only and replaced on upgrade, so there is nowhere there to put one.
 # Same variable the aartool side already honours.
 INVENTORY="${AARTOOL_INVENTORY:-$ANSIBLE_BASE/inventory/hosts}"
+# Say where the roles are rather than relying on playbooks/roles being a symlink
+# to ../roles. That symlink is how a git checkout resolves them, and a packaging
+# step that quietly drops it leaves playbooks referencing roles nothing can find.
+# Explicit beats implicit for the one path without which nothing runs.
+export ANSIBLE_ROLES_PATH="$ANSIBLE_BASE/roles"
+
 PLAYBOOK_1="$ANSIBLE_BASE/playbooks/1_execute_baseline_before.yml"
 PLAYBOOK_2="$ANSIBLE_BASE/playbooks/2_configure_hardening.yml"
 PLAYBOOK_3="$ANSIBLE_BASE/playbooks/3_execute_baseline_after.yml"


### PR DESCRIPTION
Found on the first real `aartool plan --target localhost` from a package install.

```
ERROR! the role 'linux_kernel_hardening_rhel9' was not found in
  /usr/share/aartool/ansible-hardening/playbooks/roles:/root/.ansible/roles:...
```

## nfpm drops symlinks inside a directory tree

`ansible-hardening/playbooks/roles` is a symlink to `../roles`. It is what lets Ansible resolve the roles from a playbook one directory down, and it is tracked in git, so a checkout works.

nfpm copied the four playbooks and **dropped the link without a word**. Every package shipped playbooks referencing roles nothing could find.

That is 3.3.0 and 3.3.1. `inspect`, `advise`, `explain`, `surface`, `report` and `diff` all worked, so the package looked healthy while half the tool did not run.

## Fixed twice over

The one path without which nothing runs should not depend on a symlink surviving a packaging step:

- `nfpm.yaml` declares the link explicitly as a `type: symlink` entry
- `run-hardening.sh` exports `ANSIBLE_ROLES_PATH="$ANSIBLE_BASE/roles"`

## The test that should have existed

`install-test.sh` now runs `ansible-playbook --syntax-check` against the **installed** playbook, which is exactly the step that was failing.

Proven by removing the symlink entry and rebuilding:

```
ERROR! the role 'linux_kernel_hardening_rhel9' was not found in ...
-> FAIL (exit 1)     debian:12
-> FAIL (exit 1)     rockylinux:9
0 passed, 2 failed
```

and restored:

```
roles symlink:      present
playbook parses:    roles and collections resolve
2 passed, 0 failed
```

**Counting the shipped roles would not have caught this.** The count was always right: 52 roles, all present, none reachable.

## Which immediately found a second gap

The roles call `ansible.posix` (sysctl, firewalld, selinux, seboolean) and `community.general` (ufw), and neither is in the package. `plan` and `apply` now check before starting:

```
[ERROR] Missing Ansible collection(s): ansible.posix community.general
        The hardening roles use them for sysctl, firewalld, selinux and ufw.
        Install them:
          ansible-galaxy collection install -r /usr/share/aartool/ansible-hardening/requirements.yml
```

rather than letting Ansible fail with `couldn't resolve module/action 'ansible.posix.selinux'` pointing at a line inside a role, which reads like a bug in the role rather than a missing dependency on the machine.

They stay unvendored deliberately: `community.general` alone is **29 MB against a 480 KB package**, and this tool is aimed at machines with constrained bandwidth. Ansible itself is already only a recommended dependency for the same reason.

## One thing I removed

I first wrote a probe asserting the missing-collections message appears, by pointing `ANSIBLE_COLLECTIONS_PATH` at a nonexistent directory. It did not reliably simulate the condition and it ran a real playbook inside a container, which failed for unrelated reasons. A test that fails for the wrong reason is worse than no test, so it is gone. The preflight remains, and is worth verifying on a real machine.

```
test_aartool 109 · test_docs 183 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
839 assertions, 0 failed
```
