### PR TITLE
feat(inspect): a table you can read, and the score at the end of it

### DIFF
--- a/docs/AARTOOL.md
+++ b/docs/AARTOOL.md
@@ -275,6 +275,28 @@ than in aartool.
 
 ### `inspect`
 
+Results stream as they run, one aligned row per check, grouped into the eight
+families:
+
+```
+── 3. SSH HARDENING ────────────────────────────────────────────────
+  STATUS ID        CHECK                                      DETAIL
+  FAIL   SSH-01    Root login permitted                       PermitRootLogin yes
+  PASS   SSH-02    Password authentication disabled           PasswordAuthentication no
+```
+
+The **check ID is in the second column** because `aartool explain SSH-01` needs
+it, and it used to appear only in the JSON report.
+
+The score is the **last** thing printed. It used to sit in the middle, with a
+117-line remediation block after it: `aartool advise` does that job properly,
+ordered by what an attacker reaches first and with the cost of each fix, so
+inspect points at it rather than duplicating it worse.
+
+`--hints` prints a one-line fix under each finding. It is off by default because
+it roughly doubles the length of a 109-check run, and `explain <ID>` gives the
+same thing in full plus what closing the finding breaks.
+
 Audit a machine. Changes nothing.
 
 | option | meaning |

--- a/scripts/aartool
+++ b/scripts/aartool
@@ -1704,6 +1704,7 @@ Options:
   --ssh-opt OPT         Extra ssh option, repeatable
   -o, --out DIR         Write reports to DIR. Default: ./reports
   --no-save             Print to the terminal and write nothing
+  --hints               Print a one-line fix under each finding
   -h, --help            Show this help
 
 With no --host, --host-file or --inventory, aartool audits the machine it is
@@ -1742,6 +1743,10 @@ cmd_inspect() {
         [[ $# -ge 2 ]] || die "$1 needs a value."
         out_dir="$2"; save=true; shift 2 ;;
       --no-save) save=false; shift ;;
+      # Off by default: printing a fix under every non-PASS check doubled the
+      # length of a 109-check run. `aartool explain <ID>` gives the same thing
+      # in full, plus what closing the finding costs.
+      --hints)   export AARTOOL_HINTS=1; shift ;;
       -h|--help) cmd_inspect_usage; return 0 ;;
       --) shift; break ;;
       -*) die "Unknown option for inspect: $1. Try 'aartool inspect --help'." ;;

--- a/scripts/aartool-src/cmd/inspect.sh
+++ b/scripts/aartool-src/cmd/inspect.sh
@@ -25,6 +25,7 @@ Options:
   --ssh-opt OPT         Extra ssh option, repeatable
   -o, --out DIR         Write reports to DIR. Default: ./reports
   --no-save             Print to the terminal and write nothing
+  --hints               Print a one-line fix under each finding
   -h, --help            Show this help
 
 With no --host, --host-file or --inventory, aartool audits the machine it is
@@ -63,6 +64,10 @@ cmd_inspect() {
         [[ $# -ge 2 ]] || die "$1 needs a value."
         out_dir="$2"; save=true; shift 2 ;;
       --no-save) save=false; shift ;;
+      # Off by default: printing a fix under every non-PASS check doubled the
+      # length of a 109-check run. `aartool explain <ID>` gives the same thing
+      # in full, plus what closing the finding costs.
+      --hints)   export AARTOOL_HINTS=1; shift ;;
       -h|--help) cmd_inspect_usage; return 0 ;;
       --) shift; break ;;
       -*) die "Unknown option for inspect: $1. Try 'aartool inspect --help'." ;;

--- a/scripts/cyberaar-baseline.sh
+++ b/scripts/cyberaar-baseline.sh
@@ -680,6 +680,7 @@ fi
 # ─── COLORS ──────────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
 CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+DIM='\033[2m'   # column headers and IDs: present, but not competing with the result
 
 # ─── GLOBALS ─────────────────────────────────────────────────────────────────
 PASS=0; WARN=0; FAIL=0
@@ -699,8 +700,19 @@ WARN_IDS=()
 
 # ─── HELPERS ─────────────────────────────────────────────────────────────────
 
+# A fixed-width rule with a column header, so a section reads as a table rather
+# than as a stream. The old version appended a fixed-length bar to a
+# variable-length title, so every section ended at a different column.
+REPORT_WIDTH=86
 section() {
-  printf "\n${BOLD}${CYAN}━━━  %s  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n" "$1"
+  local title="$1" pad
+  # Titles are "1. SYSTEM & OS / Systeme et OS": keep the English half for the
+  # terminal, where the column header is English too.
+  title="${title%% / *}"
+  pad=$(( REPORT_WIDTH - ${#title} - 6 ))
+  (( pad < 3 )) && pad=3
+  printf "\n${BOLD}${CYAN}── %s %s${NC}\n" "$title" "$(printf '─%.0s' $(seq 1 "$pad"))"
+  printf "${DIM}  %-6s %-9s %-42s %s${NC}\n" "STATUS" "ID" "CHECK" "DETAIL"
 }
 
 # Encode special HTML characters to prevent XSS in report output
@@ -746,11 +758,23 @@ add_result() {
     FAIL) ((FAIL++)); symbol="❌"; color=$RED;    FAIL_IDS+=("$id") ;;
   esac
 
-  # Terminal — live streaming output (unchanged behaviour)
-  printf "  ${color}${symbol}  ${BOLD}[%-6s]${NC}${color} %-45s${NC} %s\n" \
-    "$status" "$name_en" "$detail"
-  if [[ "$status" != "PASS" && -n "$remediation" ]]; then
-    printf "         ${CYAN}↳ %s${NC}\n" "$remediation"
+  # Terminal: one aligned row per check, streamed as it runs.
+  #
+  # No emoji in this column. ✅ is one cell wide, ⚠️ is two plus a variation
+  # selector, and ❌ is two: mixing them means no two rows line up, which is
+  # most of why 109 results read as a wall. The status word carries the colour
+  # and aligns.
+  #
+  # The ID is printed because `aartool explain SSH-01` needs it, and until now
+  # the only place to find it was the JSON report.
+  printf "  ${color}%-6s${NC} ${DIM}%-9s${NC} %-42s %s\n" \
+    "$status" "$id" "$name_en" "$detail"
+
+  # Per-check hints are off by default: they doubled the length of every run,
+  # and `aartool explain <ID>` gives the same thing in full, plus what closing
+  # the finding costs. AARTOOL_HINTS=1, or `aartool inspect --hints`.
+  if [[ "${AARTOOL_HINTS:-0}" == "1" && "$status" != "PASS" && -n "$remediation" ]]; then
+    printf "         ${CYAN}hint: %s${NC}\n" "$remediation"
   fi
 
   # Append to parallel result arrays (renderers iterate these at end of run)
@@ -2257,12 +2281,23 @@ _render_summary() {
   if   [[ "$SCORE" -ge 80 ]]; then printf "${GREEN}${BOLD}%s%%${NC}\n" "$SCORE"
   elif [[ "$SCORE" -ge 60 ]]; then printf "${YELLOW}${BOLD}%s%%${NC}\n" "$SCORE"
   else printf "${RED}${BOLD}%s%%${NC}\n" "$SCORE"; fi
-  printf "  ✅ PASS: %-4s  ⚠️  WARN: %-4s  ❌ FAIL: %-4s  (Total: %s)\n" "$PASS" "$WARN" "$FAIL" "$TOTAL"
-  printf "  🖥  Host: %-28s  📅 %s\n" "$HOSTNAME_VAL" "$DATE_VAL"
+  printf "  ${GREEN}PASS %-4s${NC}  ${YELLOW}WARN %-4s${NC}  ${RED}FAIL %-4s${NC}  of %s checks\n" \
+    "$PASS" "$WARN" "$FAIL" "$TOTAL"
+  printf "  %s  ·  %s\n" "$HOSTNAME_VAL" "$DATE_VAL"
   printf "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-  printf "  CyberAar — https://github.com/cyberaar/aartool\n\n"
 
-  _ansible_terminal_plan
+  # The remediation plan used to print here, after the score, which put the one
+  # number anybody looks for in the middle of the output with 117 lines below
+  # it. `aartool advise` does that job properly: ordered by what an attacker
+  # reaches first, with the cost of each fix, rather than grouped by Ansible
+  # tag. Duplicating it worse, in the way of the score, helped nobody.
+  #
+  # _ansible_terminal_plan is still defined and still used by the HTML report.
+  printf "\n  ${CYAN}Next:${NC}  aartool advise   what to fix first, and what each fix costs\n"
+  if [[ "${AARTOOL_HINTS:-0}" != "1" ]]; then
+    printf "         ${DIM}aartool inspect --hints   to see a one-line fix under each finding${NC}\n"
+  fi
+  printf "\n"
 }
 
 # =============================================================================

--- a/scripts/src/lib/core.sh
+++ b/scripts/src/lib/core.sh
@@ -1,6 +1,7 @@
 # ─── COLORS ──────────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
 CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+DIM='\033[2m'   # column headers and IDs: present, but not competing with the result
 
 # ─── GLOBALS ─────────────────────────────────────────────────────────────────
 PASS=0; WARN=0; FAIL=0
@@ -20,8 +21,19 @@ WARN_IDS=()
 
 # ─── HELPERS ─────────────────────────────────────────────────────────────────
 
+# A fixed-width rule with a column header, so a section reads as a table rather
+# than as a stream. The old version appended a fixed-length bar to a
+# variable-length title, so every section ended at a different column.
+REPORT_WIDTH=86
 section() {
-  printf "\n${BOLD}${CYAN}━━━  %s  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n" "$1"
+  local title="$1" pad
+  # Titles are "1. SYSTEM & OS / Systeme et OS": keep the English half for the
+  # terminal, where the column header is English too.
+  title="${title%% / *}"
+  pad=$(( REPORT_WIDTH - ${#title} - 6 ))
+  (( pad < 3 )) && pad=3
+  printf "\n${BOLD}${CYAN}── %s %s${NC}\n" "$title" "$(printf '─%.0s' $(seq 1 "$pad"))"
+  printf "${DIM}  %-6s %-9s %-42s %s${NC}\n" "STATUS" "ID" "CHECK" "DETAIL"
 }
 
 # Encode special HTML characters to prevent XSS in report output
@@ -67,11 +79,23 @@ add_result() {
     FAIL) ((FAIL++)); symbol="❌"; color=$RED;    FAIL_IDS+=("$id") ;;
   esac
 
-  # Terminal — live streaming output (unchanged behaviour)
-  printf "  ${color}${symbol}  ${BOLD}[%-6s]${NC}${color} %-45s${NC} %s\n" \
-    "$status" "$name_en" "$detail"
-  if [[ "$status" != "PASS" && -n "$remediation" ]]; then
-    printf "         ${CYAN}↳ %s${NC}\n" "$remediation"
+  # Terminal: one aligned row per check, streamed as it runs.
+  #
+  # No emoji in this column. ✅ is one cell wide, ⚠️ is two plus a variation
+  # selector, and ❌ is two: mixing them means no two rows line up, which is
+  # most of why 109 results read as a wall. The status word carries the colour
+  # and aligns.
+  #
+  # The ID is printed because `aartool explain SSH-01` needs it, and until now
+  # the only place to find it was the JSON report.
+  printf "  ${color}%-6s${NC} ${DIM}%-9s${NC} %-42s %s\n" \
+    "$status" "$id" "$name_en" "$detail"
+
+  # Per-check hints are off by default: they doubled the length of every run,
+  # and `aartool explain <ID>` gives the same thing in full, plus what closing
+  # the finding costs. AARTOOL_HINTS=1, or `aartool inspect --hints`.
+  if [[ "${AARTOOL_HINTS:-0}" == "1" && "$status" != "PASS" && -n "$remediation" ]]; then
+    printf "         ${CYAN}hint: %s${NC}\n" "$remediation"
   fi
 
   # Append to parallel result arrays (renderers iterate these at end of run)

--- a/scripts/src/renderers/terminal.sh
+++ b/scripts/src/renderers/terminal.sh
@@ -81,10 +81,21 @@ _render_summary() {
   if   [[ "$SCORE" -ge 80 ]]; then printf "${GREEN}${BOLD}%s%%${NC}\n" "$SCORE"
   elif [[ "$SCORE" -ge 60 ]]; then printf "${YELLOW}${BOLD}%s%%${NC}\n" "$SCORE"
   else printf "${RED}${BOLD}%s%%${NC}\n" "$SCORE"; fi
-  printf "  ✅ PASS: %-4s  ⚠️  WARN: %-4s  ❌ FAIL: %-4s  (Total: %s)\n" "$PASS" "$WARN" "$FAIL" "$TOTAL"
-  printf "  🖥  Host: %-28s  📅 %s\n" "$HOSTNAME_VAL" "$DATE_VAL"
+  printf "  ${GREEN}PASS %-4s${NC}  ${YELLOW}WARN %-4s${NC}  ${RED}FAIL %-4s${NC}  of %s checks\n" \
+    "$PASS" "$WARN" "$FAIL" "$TOTAL"
+  printf "  %s  ·  %s\n" "$HOSTNAME_VAL" "$DATE_VAL"
   printf "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-  printf "  CyberAar — https://github.com/cyberaar/aartool\n\n"
 
-  _ansible_terminal_plan
+  # The remediation plan used to print here, after the score, which put the one
+  # number anybody looks for in the middle of the output with 117 lines below
+  # it. `aartool advise` does that job properly: ordered by what an attacker
+  # reaches first, with the cost of each fix, rather than grouped by Ansible
+  # tag. Duplicating it worse, in the way of the score, helped nobody.
+  #
+  # _ansible_terminal_plan is still defined and still used by the HTML report.
+  printf "\n  ${CYAN}Next:${NC}  aartool advise   what to fix first, and what each fix costs\n"
+  if [[ "${AARTOOL_HINTS:-0}" != "1" ]]; then
+    printf "         ${DIM}aartool inspect --hints   to see a one-line fix under each finding${NC}\n"
+  fi
+  printf "\n"
 }

--- a/scripts/tests/test_aartool.sh
+++ b/scripts/tests/test_aartool.sh
@@ -86,6 +86,7 @@ check    "uninstall reaches install" "$($AARTOOL uninstall --help 2>&1)"  "aarto
 # localhost is the machine inspect just audited, and it needs no inventory.
 # Before this, hardening the obvious first target failed on a package install,
 # where there is no inventory and nowhere writable to put one.
+check    "inspect documents --hints" "$($AARTOOL inspect --help 2>&1)"     "--hints"
 check    "plan documents localhost"  "$($AARTOOL plan --help 2>&1)"       "localhost"
 check    "apply documents localhost" "$($AARTOOL apply --help 2>&1)"      "localhost"
 
@@ -398,6 +399,43 @@ done
 check_rc "advise with no report exits 1" 1 env HOME=/nonexistent $AARTOOL advise --wave 1
 check "advise rejects a non-report" \
       "$($AARTOOL advise ../README.md 2>&1)" "does not look like"
+
+# ── The shape of an inspect run ──────────────────────────────────────────────
+#
+# 109 results used to print as 327 lines with the score in the middle of them,
+# because every non-PASS check carried a fix and a 117-line remediation block
+# followed the score. Both are gone from the default output; the score is the
+# last thing before the pointer to advise.
+_core=src/lib/core.sh
+_term=src/renderers/terminal.sh
+
+# Assert the files are there before grepping them. A wrong path makes every
+# `if grep -q ... ; then bad; else ok; fi` check pass for the wrong reason,
+# which is how the first version of this block reported four false passes.
+for _f in "$_core" "$_term"; do
+  [[ -f "$_f" ]] && PASS=$((PASS+1)) \
+    || { FAIL=$((FAIL+1)); printf 'FAIL  %s not found; the checks below prove nothing\n' "$_f"; }
+done
+
+check "hints are off by default"   "$(cat $_core)"  'AARTOOL_HINTS:-0'
+check "check IDs are printed"      "$(cat $_core)"  '"$status" "$id" "$name_en"'
+check "section prints a header"    "$(cat $_core)"  'STATUS" "ID" "CHECK" "DETAIL"'
+
+# No emoji in the status column: they are one, two and two cells wide, so no two
+# rows line up, which is most of why 109 results read as a wall.
+if grep -qE '^\s*printf "  \$\{color\}\$\{symbol\}' "$_core"; then
+  FAIL=$((FAIL+1)); printf 'FAIL  the status column prints an emoji again; rows will not align\n'
+else
+  PASS=$((PASS+1))
+fi
+
+# The score must be the last thing the summary prints, not the middle.
+if grep -q '_ansible_terminal_plan$' "$_term"; then
+  FAIL=$((FAIL+1)); printf 'FAIL  _render_summary calls the remediation plan again; the score is back in the middle\n'
+else
+  PASS=$((PASS+1))
+fi
+check "summary points at advise"   "$(cat $_term)"  'aartool advise'
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
327 lines for 109 checks, with the one number anyone looks for sitting in the middle of them.

## Before

```
  ✅  [PASS  ] Distribution supported                        Debian GNU/Linux 12 ...
  ⚠️   [WARN  ] Kernel version                                6.18.33.2-microsoft-standard-WSL2
         ↳ Vérifiez les mises à jour noyau: 'dnf check-update kernel' ou ...
  ❌  [FAIL  ] No MAC framework                              SELinux/AppArmor absent
         ↳ Installez et activez SELinux ou AppArmor.
```

## After

```
── 1. SYSTEM & OS ──────────────────────────────────────────────────
  STATUS ID        CHECK                                      DETAIL
  PASS   SYS-01    Distribution supported                     Debian GNU/Linux 12 (bookworm)
  WARN   SYS-02    Kernel version                             6.18.33.2-microsoft-standard-WSL2
  FAIL   SYS-04    No MAC framework                           SELinux/AppArmor absent
```

**327 lines to 145.** With `--hints`, 217.

## What was breaking the alignment

Two things, and neither is obvious from reading the code:

- **The emoji.** `✅` is one cell wide, `⚠️` is two plus a variation selector, `❌` is two. No two rows could line up. The status word carries the colour and aligns.
- **The section rule** was a fixed-length bar appended to a variable-length title, so every section ended at a different column.

## The check ID is now printed

`aartool explain SSH-01` needs it, and the only place to find it was the JSON report.

## The score is last

It used to print and then be followed by 117 lines of remediation. `advise` does that job properly, ordered by what an attacker reaches first and with the cost of each fix, rather than grouped by Ansible tag. inspect now ends:

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  CyberAar Security Score: 29%
  PASS 32    WARN 61    FAIL 16    of 109 checks
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  Next:  aartool advise   what to fix first, and what each fix costs
         aartool inspect --hints   to see a one-line fix under each finding
```

## Hints move behind a flag

They printed under every non-PASS result, which is what doubled the length, and `explain <ID>` gives the same thing in full plus what closing the finding breaks.

They are also **the only French text in an English interface**. That is worth deciding deliberately rather than by default, and it is now a separate decision rather than something every run prints.

## Guarded, and both guards proven

- Put `_ansible_terminal_plan` back in `_render_summary` -> fails
- Restore the emoji status column -> fails

The first version of that test block used `../src/...` paths, which resolve outside the repository. Four checks passed while grepping nothing. The files are now asserted to exist before anything greps them, because `if grep -q X file; then bad; else ok; fi` passes for the wrong reason when the file is missing.

```
test_aartool 118 · test_docs 184 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
849 assertions, 0 failed
```
