### PR TITLE
fix(firewall): plan failed on any host without a firewall installed

### DIFF
--- a/ansible-hardening/roles/linux_firewall_ubuntu/handlers/main.yml
+++ b/ansible-hardening/roles/linux_firewall_ubuntu/handlers/main.yml
@@ -1,4 +1,9 @@
 ---
+# Gated like the tasks that notify it. Handlers run at the end of the play, so
+# during a preview on a host without ufw this fired after every task had been
+# correctly skipped, and failed with "Failed to find required executable ufw".
+# A guard on the tasks alone does not cover the handler they notify.
 - name: "Reload ufw"
   community.general.ufw:
     state: "reloaded"
+  when: _ufw_ready | default(false)

--- a/ansible-hardening/roles/linux_firewall_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_firewall_ubuntu/tasks/tasks.yml
@@ -22,27 +22,56 @@
     name: "ufw"
     state: "present"
 
+# check_mode: false so this actually looks, during a preview too. Without it
+# the command module is skipped under --check, _ufw_bin is never set, and the
+# ufw tasks below run against a binary that is not there.
 - name: "Verify ufw binary is available"
+  # `which`, not `command -v`: the command module does not use a shell, and
+  # `command` is a shell builtin. Probing with it always failed, which would
+  # have skipped every firewall rule on every host, silently.
   ansible.builtin.command: "which ufw"
   changed_when: false
+  check_mode: false
   register: "_ufw_bin"
-  failed_when: "_ufw_bin.rc != 0"
+  failed_when: false
+
+# A preview does not install anything, so on a host without ufw the package
+# task above reports "would install" and changes nothing. Configuring a
+# firewall that is not there then fails with "Failed to find required
+# executable ufw", which is a preview failing on exactly the host that most
+# needs the role. Say what apply would do instead.
+- name: "Preview: ufw is not installed yet"
+  ansible.builtin.debug:
+    msg: >-
+      ufw is not installed. A preview installs nothing, so the rules below
+      cannot be evaluated. 'aartool apply' installs ufw first, then applies
+      them.
+  when:
+    - ansible_check_mode
+    - _ufw_bin.rc != 0
+
+- name: "Set ufw availability fact"
+  ansible.builtin.set_fact:
+    _ufw_ready: "{{ (not ansible_check_mode) or (_ufw_bin.rc == 0) }}"
 
 # ── UFW rules ─────────────────────────────────────────────────────────────────
 - name: "Set UFW default incoming policy to deny"
   community.general.ufw:
     direction: "incoming"
     policy: "deny"
+  when: _ufw_ready | default(false)
 
 - name: "Set UFW default outgoing policy to allow"
   community.general.ufw:
     direction: "outgoing"
     policy: "allow"
+  when: _ufw_ready | default(false)
 
 - name: "Set UFW default forward policy to deny"
   community.general.ufw:
     direction: "routed"
     policy: "deny"
+  when: _ufw_ready | default(false)
 
 - name: "Allow SSH through UFW before enabling (prevent lockout)"
   community.general.ufw:
@@ -50,9 +79,12 @@
     port: "{{ linux_firewall_ssh_port }}"
     proto: "tcp"
     comment: "CyberAar: SSH access"
+  when: _ufw_ready | default(false)
 
 - name: "Apply custom UFW allow rules"
-  when: "linux_firewall_allow_rules | length > 0"
+  when:
+    - "linux_firewall_allow_rules | length > 0"
+    - "_ufw_ready | default(false)"
   community.general.ufw:
     rule: "allow"
     port: "{{ item.port }}"
@@ -62,7 +94,9 @@
   loop: "{{ linux_firewall_allow_rules }}"
 
 - name: "Apply custom UFW deny rules"
-  when: "linux_firewall_deny_rules | length > 0"
+  when:
+    - "linux_firewall_deny_rules | length > 0"
+    - "_ufw_ready | default(false)"
   community.general.ufw:
     rule: "deny"
     port: "{{ item.port }}"
@@ -75,8 +109,15 @@
     state: "enabled"
 
 # ── Service management (skipped on WSL without systemd) ───────────────────────
+  when: _ufw_ready | default(false)
+
+# The service does not exist either until the package is installed, so this
+# needs the same guard as the rules above: a preview cannot start a unit that
+# is not there.
 - name: "Enable UFW service"
-  when: "not _skip_service_mgmt"
+  when:
+    - not _skip_service_mgmt
+    - _ufw_ready | default(false)
   ansible.builtin.service:
     name: "ufw"
     state: "started"

--- a/ansible-hardening/roles/linux_firewalld_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_firewalld_rhel9/tasks/tasks.yml
@@ -4,6 +4,34 @@
     name: "firewalld"
     state: "present"
 
+# check_mode: false so this looks during a preview too, where the package task
+# above installs nothing. Without the guard, configuring firewalld on a host
+# that does not have it yet fails with "Failed to find required executable
+# firewall-offline-cmd": a preview failing on exactly the host that most needs
+# the role. Same defect as the ufw role.
+- name: "Verify the firewalld binary is available"
+  # `which`, not `command -v`: see the ufw role. The command module runs no
+  # shell, so a builtin can never be found.
+  ansible.builtin.command: "which firewall-cmd"
+  changed_when: false
+  check_mode: false
+  register: "_fwd_bin"
+  failed_when: false
+
+- name: "Preview: firewalld is not installed yet"
+  ansible.builtin.debug:
+    msg: >-
+      firewalld is not installed. A preview installs nothing, so the rules
+      below cannot be evaluated. 'aartool apply' installs firewalld first, then
+      applies them.
+  when:
+    - ansible_check_mode
+    - _fwd_bin.rc != 0
+
+- name: "Set firewalld availability fact"
+  ansible.builtin.set_fact:
+    _fwd_ready: "{{ (not ansible_check_mode) or (_fwd_bin.rc == 0) }}"
+
 - name: "Enable and start firewalld service"
   ansible.builtin.service:
     name: "firewalld"
@@ -46,7 +74,9 @@
   changed_when: true
 
 - name: "Allow required services in default zone"
-  when: "linux_firewalld_enabled | bool"
+  when:
+    - "linux_firewalld_enabled | bool"
+    - "_fwd_ready | default(false)"
   ansible.posix.firewalld:
     service: "{{ item }}"
     zone: "{{ linux_firewalld_default_zone }}"
@@ -56,7 +86,9 @@
   loop: "{{ linux_firewalld_allowed_services }}"
 
 - name: "Allow additional ports in default zone"
-  when: "linux_firewalld_enabled | bool"
+  when:
+    - "linux_firewalld_enabled | bool"
+    - "_fwd_ready | default(false)"
   ansible.posix.firewalld:
     port: "{{ item }}"
     zone: "{{ linux_firewalld_default_zone }}"
@@ -67,6 +99,7 @@
 
 - name: "Restrict SSH to specific source addresses (rich rules)"
   when:
+    - "_fwd_ready | default(false)"
     - "linux_firewalld_enabled | bool"
     - "linux_firewalld_ssh_sources | length > 0"
   ansible.posix.firewalld:
@@ -79,6 +112,7 @@
 
 - name: "Apply SSH rate limiting (rich rule)"
   when:
+    - "_fwd_ready | default(false)"
     - "linux_firewalld_enabled | bool"
     - "linux_firewalld_ssh_rate_limit != ''"
   ansible.posix.firewalld:
@@ -113,6 +147,7 @@
 
 - name: "Remove unexpected services from default zone"
   when:
+    - "_fwd_ready | default(false)"
     - "linux_firewalld_enabled | bool"
     - "_firewalld_active | bool"
     - "fw_info.firewalld_zones[linux_firewalld_default_zone].services | default([]) | difference(linux_firewalld_allowed_services) | length > 0"


### PR DESCRIPTION
Reported from a real run:

```
TASK [linux_firewall_ubuntu : Set UFW default incoming policy to deny]
fatal: [localhost]: FAILED! => {"msg": "Failed to find required executable \"ufw\" in paths: /usr/local/sbin:..."}
```

## Why

The role does install ufw first, so this looks impossible until you notice it was a **preview**.

A preview installs nothing. So on a host without ufw:

1. `Ensure ufw package is installed` reports "would install", changes nothing
2. `Verify ufw binary is available` is **skipped**, because command modules do not run under `--check`
3. `Set UFW default incoming policy` runs the ufw module against a binary that is not there

**The preview failed on exactly the host that most needs the firewall role.** Reproduced in a container before changing anything.

## The fix

Both firewall roles probe with `check_mode: false`, so the probe runs during a preview too, and gate their configuration on the result:

```
TASK [linux_firewall_ubuntu : Preview: ufw is not installed yet]
  "ufw is not installed. A preview installs nothing, so the rules below cannot be
   evaluated. 'aartool apply' installs ufw first, then applies them."

localhost : ok=11  changed=2  failed=0
```

The **handler** needed the same guard. Handlers run at the end of the play, so `Reload ufw` fired after every gated task had been correctly skipped, and failed on its own. Guarding the tasks looked complete right up until the run got that far.

## Two defects in the fix, both found by testing

**`command -v` is a shell builtin.** My probe first used `ansible.builtin.command: "command -v ufw"`, which runs no shell, so it always failed. Every firewall rule would have been skipped on **every** host, silently. Caught only by testing the case where ufw *is* installed, which is the test it would have been easy not to write.

**Five firewalld tasks already had a `when:` before the module key**, and my guard was appended as a second one. In YAML the later key wins, so conditions like

```yaml
when:
  - "linux_firewalld_enabled | bool"
  - "_firewalld_active | bool"
  - "fw_info.firewalld_zones[...] | difference(...) | length > 0"
```

would have been **discarded**, and services removed regardless of them. Caught by ansible-lint's `key-duplicates`, now merged into single lists.

## Verified both ways, in containers

| ufw | result |
|---|---|
| not installed | preview completes and explains itself, `failed=0` |
| installed (`--cap-add=NET_ADMIN`) | rules evaluated normally, `changed=8`, `failed=0` |

```
test_aartool 118 · test_docs 195 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
860 assertions, 0 failed
```

Remaining ansible-lint findings on these roles are `var-naming[no-role-prefix]`, 25 of which predate this change; the 3 new registers follow the `_` convention already used throughout both roles.
