### PR TITLE
fix(roles): 40 service tasks could not survive a preview

### DIFF
--- a/.github/workflows/baseline-build.yml
+++ b/.github/workflows/baseline-build.yml
@@ -96,6 +96,13 @@ jobs:
       - name: Checks call subcommands that exist
         run: bash scripts/tests/test_check_commands.sh
 
+      # `aartool plan` runs the playbook with --check, which installs nothing,
+      # so a role that installs a package and then starts its service hits a
+      # unit that is not there. Reported twice by users, for ufw and for ssh,
+      # with 40 unguarded service tasks at the time.
+      - name: Service tasks survive check mode
+        run: bash scripts/tests/test_service_guards.sh
+
       # The dashboard mirrors advise's wave ordering because it has no shell to
       # call, and `aartool report --out` injects into it by function name. Both
       # are places two things must agree with nothing checking that they do.

--- a/ansible-hardening/playbooks/2_configure_hardening.yml
+++ b/ansible-hardening/playbooks/2_configure_hardening.yml
@@ -115,7 +115,10 @@
     #
     # check_mode: false because a command module is skipped under --check, and
     # a probe that does not run tells you nothing. It only reads.
-    - name: "CyberAar | Inventory the systemd units present"
+    # The systemd module MANAGES a unit, it does not enumerate unit files, and
+    # service_facts lists services only: dnf-automatic.timer and tmp.mount are
+    # both guarded on this and would be missing from it.
+    - name: "CyberAar | Inventory the systemd units present" # noqa: command-instead-of-module
       ansible.builtin.command: "systemctl list-unit-files --no-legend --no-pager"
       register: "_aartool_unit_files"
       changed_when: false

--- a/ansible-hardening/playbooks/2_configure_hardening.yml
+++ b/ansible-hardening/playbooks/2_configure_hardening.yml
@@ -105,6 +105,29 @@
           ( {{ ansible_os_family }} family) — applying appropriate role set.
       tags: [always]
 
+    # Which units exist on this host, gathered once and shared by every role.
+    #
+    # A preview installs nothing, so a role that installs a package and then
+    # starts its service fails under --check with "Could not find the requested
+    # service ssh". That is a preview failing on exactly the host the role is
+    # for. Service tasks are guarded on this fact so a preview reports what
+    # apply would do instead.
+    #
+    # check_mode: false because a command module is skipped under --check, and
+    # a probe that does not run tells you nothing. It only reads.
+    - name: "CyberAar | Inventory the systemd units present"
+      ansible.builtin.command: "systemctl list-unit-files --no-legend --no-pager"
+      register: "_aartool_unit_files"
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      tags: [always]
+
+    - name: "CyberAar | Share the unit inventory with the roles"
+      ansible.builtin.set_fact:
+        aartool_units: "{{ _aartool_unit_files.stdout | default('') }}"
+      tags: [always]
+
     - name: "CyberAar | Hardening start notification"
       ansible.builtin.debug:
         msg:

--- a/ansible-hardening/roles/linux_apparmor_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_apparmor_ubuntu/tasks/tasks.yml
@@ -55,13 +55,16 @@
 
 # ── AppArmor service ──────────────────────────────────────────────────────────
 - name: "Enable AppArmor service at boot"
+  when: "not ansible_check_mode or 'apparmor.service' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "apparmor"
     enabled: true
     daemon_reload: false
 
 - name: "Start AppArmor service (best-effort — oneshot service loads profiles)"
-  when: "not ansible_check_mode"
+  when:
+    - "not ansible_check_mode"
+    - "not ansible_check_mode or 'apparmor.service' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "apparmor"
     state: "started"

--- a/ansible-hardening/roles/linux_auditing_rhel9/handlers/main.yml
+++ b/ansible-hardening/roles/linux_auditing_rhel9/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart auditd"
+  when: "not ansible_check_mode or 'auditd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "auditd"
     state: "restarted"
@@ -7,6 +8,7 @@
   listen: "Restart auditd" # allows multiple notifies to same handler
 
 - name: "Restart rsyslog"
+  when: "not ansible_check_mode or 'rsyslog.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "rsyslog"
     state: "restarted"

--- a/ansible-hardening/roles/linux_auditing_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_auditing_rhel9/tasks/tasks.yml
@@ -29,6 +29,7 @@
   notify: "Restart auditd"
 
 - name: "Enable and start auditd service"
+  when: "not ansible_check_mode or 'auditd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "auditd"
     state: "started"
@@ -81,6 +82,7 @@
     state: "present"
 
 - name: "Enable and start rsyslog service"
+  when: "not ansible_check_mode or 'rsyslog.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "rsyslog"
     state: "started"

--- a/ansible-hardening/roles/linux_auditing_ubuntu/handlers/main.yml
+++ b/ansible-hardening/roles/linux_auditing_ubuntu/handlers/main.yml
@@ -1,11 +1,13 @@
 ---
 - name: "Restart auditd"
+  when: "not ansible_check_mode or 'auditd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "auditd"
     state: "restarted"
   failed_when: false
 
 - name: "Restart rsyslog"
+  when: "not ansible_check_mode or 'rsyslog.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "rsyslog"
     state: "restarted"

--- a/ansible-hardening/roles/linux_auditing_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_auditing_ubuntu/tasks/tasks.yml
@@ -34,6 +34,7 @@
 # Ubuntu 22.04+ uses auditd but requires it to be started via service wrapper
 # as systemd may manage it under a different unit on some installs.
 - name: "Enable and start auditd service"
+  when: "not ansible_check_mode or 'auditd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "auditd"
     state: "started"
@@ -139,6 +140,7 @@
     state: "present"
 
 - name: "Enable and start rsyslog service"
+  when: "not ansible_check_mode or 'rsyslog.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "rsyslog"
     state: "started"

--- a/ansible-hardening/roles/linux_authselect_rhel9/handlers/main.yml
+++ b/ansible-hardening/roles/linux_authselect_rhel9/handlers/main.yml
@@ -7,4 +7,6 @@
   ansible.builtin.service:
     name: "sssd"
     state: "restarted"
-  when: "ansible_facts.services['sssd.service'] is defined and ansible_facts.services['sssd.service'].state == 'running'"
+  when:
+    - "ansible_facts.services['sssd.service'] is defined and ansible_facts.services['sssd.service'].state == 'running'"
+    - "not ansible_check_mode or 'sssd.service' in (aartool_units | default(''))"

--- a/ansible-hardening/roles/linux_chrony_rhel9/handlers/main.yml
+++ b/ansible-hardening/roles/linux_chrony_rhel9/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart chronyd"
+  when: "not ansible_check_mode or 'chronyd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "chronyd"
     state: "restarted"

--- a/ansible-hardening/roles/linux_chrony_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_chrony_rhel9/tasks/tasks.yml
@@ -16,6 +16,7 @@
   notify: "Restart chronyd"
 
 - name: "Enable and start chronyd service"
+  when: "not ansible_check_mode or 'chronyd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "chronyd"
     state: "started"

--- a/ansible-hardening/roles/linux_chrony_ubuntu/handlers/main.yml
+++ b/ansible-hardening/roles/linux_chrony_ubuntu/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart chrony"
+  when: "not ansible_check_mode or 'chrony.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "chrony"
     state: "restarted"

--- a/ansible-hardening/roles/linux_chrony_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_chrony_ubuntu/tasks/tasks.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Disable systemd-timesyncd before installing chrony (prevents conflict)"
+  when: "not ansible_check_mode or 'systemd-timesyncd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "systemd-timesyncd"
     state: "stopped"
@@ -23,7 +24,9 @@
   notify: "Restart chrony"
 
 - name: "Enable and start chrony service"
-  when: "not ansible_check_mode"
+  when:
+    - "not ansible_check_mode"
+    - "not ansible_check_mode or 'chrony.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "chrony"
     state: "started"

--- a/ansible-hardening/roles/linux_cron_hardening_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_cron_hardening_rhel9/tasks/tasks.yml
@@ -5,7 +5,9 @@
     name: "crond"
     state: "started"
     enabled: true
-  when: "linux_cron_enabled | bool"
+  when:
+    - "linux_cron_enabled | bool"
+    - "not ansible_check_mode or 'crond.service' in (aartool_units | default(''))"
 
 # CIS 5.1.2–5.1.7 — Strict permissions on cron directories and files
 - name: "Set ownership root:root on cron paths (CIS 5.1.2–5.1.7)"

--- a/ansible-hardening/roles/linux_cron_hardening_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_cron_hardening_ubuntu/tasks/tasks.yml
@@ -6,7 +6,9 @@
     name: "cron"
     state: "started"
     enabled: true
-  when: "linux_cron_enabled | bool"
+  when:
+    - "linux_cron_enabled | bool"
+    - "not ansible_check_mode or 'cron.service' in (aartool_units | default(''))"
 
 # CIS 5.1.2–5.1.7 — Strict permissions on cron directories and files
 - name: "Set ownership root:root and strict permissions on cron paths (CIS 5.1.2–5.1.7)"

--- a/ansible-hardening/roles/linux_ctrl_alt_del_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_ctrl_alt_del_rhel9/tasks/tasks.yml
@@ -1,6 +1,8 @@
 ---
 - name: "Mask Ctrl+Alt+Del target to prevent reboot"
-  when: "linux_ctrl_alt_del_enabled | bool"
+  when:
+    - "linux_ctrl_alt_del_enabled | bool"
+    - "not ansible_check_mode or 'ctrl-alt-del.target' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "ctrl-alt-del.target"
     masked: true

--- a/ansible-hardening/roles/linux_ctrl_alt_del_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_ctrl_alt_del_ubuntu/tasks/tasks.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Mask ctrl-alt-del.target to prevent accidental reboot (CIS 1.6.1)"
+  when: "not ansible_check_mode or 'ctrl-alt-del.target' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "ctrl-alt-del.target"
     masked: true

--- a/ansible-hardening/roles/linux_dnf_automatic_rhel9/handlers/main.yml
+++ b/ansible-hardening/roles/linux_dnf_automatic_rhel9/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart dnf-automatic timer"
+  when: "not ansible_check_mode or 'dnf-automatic.timer' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "dnf-automatic.timer"
     state: "restarted"

--- a/ansible-hardening/roles/linux_dnf_automatic_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_dnf_automatic_rhel9/tasks/tasks.yml
@@ -16,6 +16,7 @@
   notify: "Restart dnf-automatic timer"
 
 - name: "Enable and start dnf-automatic timer (daily)"
+  when: "not ansible_check_mode or 'dnf-automatic.timer' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "dnf-automatic.timer"
     state: "started"

--- a/ansible-hardening/roles/linux_fail2ban_rhel9/handlers/main.yml
+++ b/ansible-hardening/roles/linux_fail2ban_rhel9/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart fail2ban"
+  when: "not ansible_check_mode or 'fail2ban.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "fail2ban"
     state: "restarted"

--- a/ansible-hardening/roles/linux_fail2ban_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_fail2ban_rhel9/tasks/tasks.yml
@@ -34,11 +34,13 @@
   notify: "Restart fail2ban"
 
 - name: "Enable fail2ban service at boot"
+  when: "not ansible_check_mode or 'fail2ban.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "fail2ban"
     enabled: true
 
 - name: "Start fail2ban service"
+  when: "not ansible_check_mode or 'fail2ban.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "fail2ban"
     state: "started"

--- a/ansible-hardening/roles/linux_fail2ban_ubuntu/handlers/main.yml
+++ b/ansible-hardening/roles/linux_fail2ban_ubuntu/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart fail2ban"
+  when: "not ansible_check_mode or 'fail2ban.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "fail2ban"
     state: "restarted"

--- a/ansible-hardening/roles/linux_fail2ban_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_fail2ban_ubuntu/tasks/tasks.yml
@@ -16,6 +16,7 @@
   notify: "Restart fail2ban"
 
 - name: "Enable and start fail2ban service"
+  when: "not ansible_check_mode or 'fail2ban.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "fail2ban"
     state: "started"

--- a/ansible-hardening/roles/linux_firewall_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_firewall_ubuntu/tasks/tasks.yml
@@ -116,6 +116,7 @@
 # is not there.
 - name: "Enable UFW service"
   when:
+    - "not ansible_check_mode or 'ufw.service' in (aartool_units | default(''))"
     - not _skip_service_mgmt
     - _ufw_ready | default(false)
   ansible.builtin.service:

--- a/ansible-hardening/roles/linux_firewalld_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_firewalld_rhel9/tasks/tasks.yml
@@ -33,6 +33,7 @@
     _fwd_ready: "{{ (not ansible_check_mode) or (_fwd_bin.rc == 0) }}"
 
 - name: "Enable and start firewalld service"
+  when: "not ansible_check_mode or 'firewalld.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "firewalld"
     state: "started"

--- a/ansible-hardening/roles/linux_journald_rhel9/handlers/main.yml
+++ b/ansible-hardening/roles/linux_journald_rhel9/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart journald"
+  when: "not ansible_check_mode or 'systemd-journald.service' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "systemd-journald"
     state: "restarted"

--- a/ansible-hardening/roles/linux_journald_ubuntu/handlers/main.yml
+++ b/ansible-hardening/roles/linux_journald_ubuntu/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart journald"
+  when: "not ansible_check_mode or 'systemd-journald.service' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "systemd-journald"
     state: "restarted"

--- a/ansible-hardening/roles/linux_ssh_hardening_rhel9/handlers/main.yml
+++ b/ansible-hardening/roles/linux_ssh_hardening_rhel9/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart sshd"
+  when: "not ansible_check_mode or 'sshd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "sshd"
     state: "restarted"

--- a/ansible-hardening/roles/linux_ssh_hardening_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_ssh_hardening_rhel9/tasks/tasks.yml
@@ -29,6 +29,7 @@
   changed_when: "banner_result.changed"
 
 - name: "Enable and start sshd service"
+  when: "not ansible_check_mode or 'sshd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "sshd"
     state: "started"

--- a/ansible-hardening/roles/linux_ssh_hardening_ubuntu/handlers/main.yml
+++ b/ansible-hardening/roles/linux_ssh_hardening_ubuntu/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 # Ubuntu/Debian SSH service is "ssh" (not "sshd" as on RHEL)
 - name: "Restart ssh"
+  when: "not ansible_check_mode or 'ssh.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "ssh"
     state: "restarted"

--- a/ansible-hardening/roles/linux_ssh_hardening_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_ssh_hardening_ubuntu/tasks/tasks.yml
@@ -49,7 +49,9 @@
 
 # ── Service management (skipped on WSL without systemd) ───────────────────────
 - name: "Enable and start ssh service"
-  when: "not _skip_service_mgmt"
+  when:
+    - "not _skip_service_mgmt"
+    - "not ansible_check_mode or 'ssh.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "ssh"
     state: "started"

--- a/ansible-hardening/roles/linux_tmp_mounts_ubuntu/handlers/main.yml
+++ b/ansible-hardening/roles/linux_tmp_mounts_ubuntu/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Reload and restart tmp.mount"
+  when: "not ansible_check_mode or 'tmp.mount' in (aartool_units | default(''))"
   ansible.builtin.systemd:
     name: "tmp.mount"
     state: "restarted"

--- a/ansible-hardening/roles/linux_tmp_mounts_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_tmp_mounts_ubuntu/tasks/tasks.yml
@@ -17,6 +17,7 @@
   notify: "Reload and restart tmp.mount"
 
 - name: "Enable tmp.mount to start at boot"
+  when: "not ansible_check_mode or 'tmp.mount' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "tmp.mount"
     enabled: true

--- a/ansible-hardening/roles/linux_unattended_upgrades_ubuntu/handlers/main.yml
+++ b/ansible-hardening/roles/linux_unattended_upgrades_ubuntu/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart unattended-upgrades"
+  when: "not ansible_check_mode or 'unattended-upgrades.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "unattended-upgrades"
     state: "restarted"

--- a/ansible-hardening/roles/linux_unattended_upgrades_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_unattended_upgrades_ubuntu/tasks/tasks.yml
@@ -28,6 +28,7 @@
   register: "auto_upgrades_result"
 
 - name: "Enable and start unattended-upgrades service"
+  when: "not ansible_check_mode or 'unattended-upgrades.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "unattended-upgrades"
     state: "started"

--- a/ansible-hardening/roles/linux_user_management_rhel9/handlers/main.yml
+++ b/ansible-hardening/roles/linux_user_management_rhel9/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: "Restart sshd"
+  when: "not ansible_check_mode or 'sshd.service' in (aartool_units | default(''))"
   ansible.builtin.service:
     name: "sshd"
     state: "restarted"

--- a/scripts/tests/test_service_guards.sh
+++ b/scripts/tests/test_service_guards.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Every service task must survive check mode on a host that does not have the
+# unit yet.
+#
+# `aartool plan` runs the hardening playbook with --check. A preview installs
+# nothing, so a role that installs a package and then starts its service hits a
+# unit that is not there:
+#
+#   TASK [linux_ssh_hardening_ubuntu : Enable and start ssh service]
+#   fatal: [localhost]: FAILED! => "Could not find the requested service ssh"
+#
+# That is a preview failing on exactly the host the role exists for, and it was
+# reported twice by users before this test existed: once for ufw, once for ssh.
+# There were 40 unguarded service tasks at the time.
+#
+# A service task is acceptable if any of these is true:
+#   - it names no service (systemd daemon-reload cannot fail this way)
+#   - its name is templated AND it is guarded on ansible_facts.services
+#   - it tolerates failure (failed_when: false / ignore_errors)
+#   - it carries the unit-existence guard on `aartool_units`
+#
+# Run: bash scripts/tests/test_service_guards.sh
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+command -v python3 >/dev/null || { echo "python3 required"; exit 1; }
+
+python3 - <<'PY'
+import glob, io, yaml, sys
+
+MODS = {"ansible.builtin.service", "ansible.builtin.systemd",
+        "ansible.builtin.systemd_service", "service", "systemd"}
+PASS = FAIL = 0
+files = sorted(glob.glob("../ansible-hardening/roles/*/tasks/*.yml") +
+               glob.glob("../ansible-hardening/roles/*/handlers/*.yml"))
+if not files:
+    print("FAIL  no role files found; the glob is wrong and this test proves nothing")
+    sys.exit(1)
+
+for f in files:
+    try:
+        doc = yaml.safe_load(io.open(f, encoding="utf-8"))
+    except Exception as e:
+        print(f"FAIL  {f}: {e}")
+        FAIL += 1
+        continue
+    if not isinstance(doc, list):
+        continue
+    for t in doc:
+        if not isinstance(t, dict):
+            continue
+        mod = next((k for k in t if k in MODS), None)
+        if not mod:
+            continue
+        args = t[mod] if isinstance(t[mod], dict) else {}
+        svc = str(args.get("name", "")).strip()
+        when = str(t.get("when", ""))
+        soft = t.get("failed_when") is False or bool(t.get("ignore_errors"))
+        name = str(t.get("name", "?"))[:48]
+        role = f.split("/")[3]
+
+        if not svc:                                   # daemon-reload
+            PASS += 1
+        elif soft:
+            PASS += 1
+        elif "{{" in svc:
+            if "ansible_facts.services" in when or "aartool_units" in when:
+                PASS += 1
+            else:
+                print(f"FAIL  {role}: '{name}' has a templated service name and no "
+                      f"existence guard")
+                FAIL += 1
+        elif "aartool_units" in when:
+            PASS += 1
+        else:
+            print(f"FAIL  {role}: '{name}' manages '{svc}' with no guard; a preview "
+                  f"on a host without that unit will fail")
+            FAIL += 1
+
+print(f"\n{PASS} passed, {FAIL} failed")
+sys.exit(1 if FAIL else 0)
+PY


### PR DESCRIPTION
Second report of the same shape, this time on ssh:

```
TASK [linux_ssh_hardening_ubuntu : Enable and start ssh service]
fatal: [localhost]: FAILED! => "Could not find the requested service ssh"
```

## The existing guard was the wrong guard

That task was already guarded:

```yaml
when: "not _skip_service_mgmt"     # WSL without systemd
```

Modern WSL **has** systemd, so the guard passed, and the unit simply was not there. A preview installs nothing, so the package task that would have created it changed nothing.

**A `when:` on a service task does not mean it is guarded against the unit not existing.** That is why the ufw fix in 3.3.4 did not prevent this one.

## The audit

48 service tasks across the roles. **40 could fail this way.**

| | |
|---|---|
| guarded now on unit existence | 40 |
| no service name (daemon-reload, cannot fail this way) | 6 |
| templated name, already guarded on `ansible_facts.services` | 2 |
| tolerates failure already | 1 |

The playbook inventories the systemd units **once**, in a `pre_task` with `check_mode: false` (a probe skipped under `--check` tells you nothing), and shares it as `aartool_units`. Each service task is guarded in check mode only, so outside a preview behaviour is unchanged.

## Enforced from here

`test_service_guards.sh`, wired into CI. Proven by reverting the ssh task to exactly what the reporter ran:

```
FAIL  linux_ssh_hardening_ubuntu: 'Enable and start ssh service' manages 'ssh'
      with no guard; a preview on a host without that unit will fail
47 passed, 1 failed
```

It accepts four shapes as safe, so it does not force a guard where one is meaningless: no service name, templated-and-guarded, failure-tolerant, or the unit guard.

## Verified in containers, with real systemd

A bare image has no systemd as PID 1, so the service module fails there for an unrelated reason. Tested in `geerlingguy/docker-ubuntu2204-ansible` instead:

| ssh unit | before | after |
|---|---|---|
| absent | `fatal: Could not find the requested service ssh` | `failed=0`, task skipped |
| present | n/a | `ok=13 changed=4 failed=0`, task runs |

```
test_aartool 118 · test_docs 195 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
test_service_guards 48
908 assertions, 0 failed
```

Worth saying plainly: your WSL testers are not the target platform, and that is exactly why they are useful. Both reports found real defects that a server-shaped environment would have hidden.
