### PR TITLE
fix(plan): a preview now runs to completion on a fresh host

### DIFF
--- a/ansible-hardening/roles/linux_aide_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_aide_ubuntu/tasks/tasks.yml
@@ -47,6 +47,12 @@
   when:
     - "not aide_db_stat.stat.exists or aide_conf_result.changed"
     - "not aide_db_new_stat.stat.exists"
+    # Ansible refuses async under --check: "check mode and async cannot be used
+    # on same task". It is a validation error, raised before the task would
+    # have been skipped for being a command, so the run dies rather than
+    # previewing. A command task changes nothing in check mode anyway, so there
+    # is nothing to preview here beyond saying it would run.
+    - "not ansible_check_mode"
   ansible.builtin.command: "aide --config /etc/aide/aide.conf --init"
   register: "aide_init"
   # rc=0: success  rc=14: db init ok but warnings  both are fine
@@ -54,6 +60,17 @@
   changed_when: "aide_init.rc in [0, 14]"
   async: 600 # AIDE init can take several minutes on a full filesystem
   poll: 15
+
+- name: "Preview: the AIDE database would be initialised"
+  when:
+    - "ansible_check_mode"
+    - "not aide_db_stat.stat.exists or aide_conf_result.changed"
+    - "not aide_db_new_stat.stat.exists"
+  ansible.builtin.debug:
+    msg: >-
+      aide --init would run here and build the baseline database. It is not run
+      in a preview: it takes minutes on a full filesystem and writes
+      /var/lib/aide/aide.db.new.
 
 - name: "Activate the newly initialized AIDE database" # noqa: no-handler
   when: "aide_init.changed | default(false)"

--- a/ansible-hardening/roles/linux_bootloader_password_rhel9/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_bootloader_password_rhel9/tasks/tasks.yml
@@ -1,20 +1,21 @@
 ---
-- name: "Fail if GRUB password is not provided via environment variable"
+- name: "Note: GRUB password role skipped, no password provided"
   when: "linux_bootloader_password is undefined or linux_bootloader_password == ''"
-  ansible.builtin.fail:
-    msg: >
-      GRUB bootloader password is not defined.
-      Set it before running, without putting it on the command line where
+  ansible.builtin.debug:
+    msg: >-
+      No GRUB bootloader password provided, so this role is skipped. Everything
+      else still runs. To set one, without putting it on the command line where
       shell history would keep it in clear:
         read -sr LINUX_BOOTLOADER_PASSWORD ; export LINUX_BOOTLOADER_PASSWORD
-  no_log: "{{ linux_bootloader_disable_nolog | default(false) | ternary(false, true) }}"
 
 - name: "Ensure grub2-tools are installed (needed for mkpasswd-pbkdf2)"
+  when: "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.package:
     name: "grub2-tools"
     state: "present"
 
 - name: "Generate PBKDF2 hashed password for GRUB"
+  when: "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.command: >-
     grub2-mkpasswd-pbkdf2 --iteration-count=100000
   args:
@@ -24,11 +25,13 @@
   no_log: "{{ linux_bootloader_disable_nolog | default(false) | ternary(false, true) }}"
 
 - name: "Parse the generated GRUB PBKDF2 hash"
+  when: "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.set_fact:
     grub_pbkdf2_hash: "{{ grub_pbkdf2_output.stdout | regex_search('grub\\.pbkdf2\\.sha512\\.\\S+') }}"
   no_log: "{{ linux_bootloader_disable_nolog | default(false) | ternary(false, true) }}"
 
 - name: "Deploy GRUB password configuration file (/etc/grub.d/01_users)"
+  when: "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.template:
     src: "01_users.j2"
     dest: "/etc/grub.d/01_users"
@@ -39,6 +42,7 @@
   register: "grub_users_result"
 
 - name: "Check if EFI grub.cfg exists"
+  when: "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.stat:
     path: "/boot/efi/EFI/{{ ansible_distribution | lower }}/grub.cfg"
   register: "grub_efi_cfg_check"
@@ -46,6 +50,7 @@
 
 - name: "Rebuild GRUB config after password deploy (EFI path)"
   when:
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
     - "grub_users_result.changed"
     - "grub_efi_cfg_check.stat.exists | default(false)"
   ansible.builtin.command: >-
@@ -56,6 +61,7 @@
 
 - name: "Rebuild GRUB config after password deploy (BIOS path)"
   when:
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
     - "grub_users_result.changed"
     - "not (grub_efi_cfg_check.stat.exists | default(false))"
   ansible.builtin.command: "grub2-mkconfig -o /boot/grub2/grub.cfg"
@@ -64,6 +70,7 @@
   notify: "GRUB config updated - reboot recommended"
 
 - name: "Ensure GRUB config file has strict permissions"
+  when: "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.file:
     path: "/boot/grub2/grub.cfg"
     mode: "0600"
@@ -73,6 +80,7 @@
 
 - name: "Remove legacy / obsolete GRUB user.cfg in EFI path (if exists)"
   when:
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
     - ansible_distribution == 'RedHat' or ansible_distribution in ['AlmaLinux', 'Rocky']
     - ansible_distribution_major_version == '9'
     - ansible_facts['mounts'] | selectattr('mount', 'equalto', '/boot/efi') | list | length > 0 # only if EFI present
@@ -84,7 +92,9 @@
   failed_when: false
 
 - name: "Debug GRUB password application status"
-  when: "ansible_verbosity >= 1"
+  when:
+    - "ansible_verbosity >= 1"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.debug:
     msg:
       - "GRUB password protection applied: {{ 'yes' if grub_users_result.changed else 'already present' }}"
@@ -96,7 +106,9 @@
 # every systemd package update and would silently revert the change.
 
 - name: "Create rescue.service.d drop-in directory (CIS 1.5.3)"
-  when: "linux_single_user_auth | bool"
+  when:
+    - "linux_single_user_auth | bool"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.file:
     path: "/etc/systemd/system/rescue.service.d"
     state: directory
@@ -105,7 +117,9 @@
     mode: "0755"
 
 - name: "Create emergency.service.d drop-in directory (CIS 1.5.3)"
-  when: "linux_single_user_auth | bool"
+  when:
+    - "linux_single_user_auth | bool"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.file:
     path: "/etc/systemd/system/emergency.service.d"
     state: directory
@@ -114,7 +128,9 @@
     mode: "0755"
 
 - name: "Deploy rescue.service override — require root authentication (CIS 1.5.3)"
-  when: "linux_single_user_auth | bool"
+  when:
+    - "linux_single_user_auth | bool"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.copy:
     dest: "/etc/systemd/system/rescue.service.d/99-cis-auth.conf"
     content: |
@@ -128,7 +144,9 @@
   notify: "Reload systemd daemon"
 
 - name: "Deploy emergency.service override — require root authentication (CIS 1.5.3)"
-  when: "linux_single_user_auth | bool"
+  when:
+    - "linux_single_user_auth | bool"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.copy:
     dest: "/etc/systemd/system/emergency.service.d/99-cis-auth.conf"
     content: |
@@ -142,7 +160,9 @@
   notify: "Reload systemd daemon"
 
 - name: "Debug single user mode auth status (verbosity >=1)"
-  when: "ansible_verbosity >= 1"
+  when:
+    - "ansible_verbosity >= 1"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.debug:
     msg:
       - "rescue.service auth applied: {{ rescue_service_result.changed | default(false) }}"

--- a/ansible-hardening/roles/linux_bootloader_password_ubuntu/tasks/tasks.yml
+++ b/ansible-hardening/roles/linux_bootloader_password_ubuntu/tasks/tasks.yml
@@ -17,19 +17,21 @@
       WSL boots via the Windows bootloader; grub-mkpasswd-pbkdf2 is not applicable.
 
 # ── All remaining tasks skipped on WSL ───────────────────────────────────────
-- name: "Fail if GRUB password is not provided via environment variable"
+- name: "Note: GRUB password role skipped, no password provided"
   when:
     - "not _is_wsl"
     - "linux_bootloader_password is undefined or linux_bootloader_password == ''"
-  ansible.builtin.fail:
-    msg: >
-      GRUB bootloader password is not defined.
-      Set it before running:
+  ansible.builtin.debug:
+    msg: >-
+      No GRUB bootloader password provided, so this role is skipped. Everything
+      else still runs. To set one, without putting it on the command line where
+      shell history would keep it in clear:
         read -sr LINUX_BOOTLOADER_PASSWORD ; export LINUX_BOOTLOADER_PASSWORD
-  no_log: "{{ linux_bootloader_disable_nolog | default(false) | ternary(false, true) }}"
 
 - name: "Ensure grub2-common package is installed"
-  when: "not _is_wsl"
+  when:
+    - "not _is_wsl"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.package:
     name:
       - "grub2-common"
@@ -37,7 +39,9 @@
     state: "present"
 
 - name: "Generate PBKDF2 hashed password for GRUB"
-  when: "not _is_wsl"
+  when:
+    - "not _is_wsl"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.command: grub-mkpasswd-pbkdf2
   args:
     stdin: "{{ linux_bootloader_password }}\n{{ linux_bootloader_password }}\n"
@@ -46,13 +50,17 @@
   no_log: "{{ linux_bootloader_disable_nolog | default(false) | ternary(false, true) }}"
 
 - name: "Parse the generated GRUB PBKDF2 hash"
-  when: "not _is_wsl"
+  when:
+    - "not _is_wsl"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.set_fact:
     grub_pbkdf2_hash: "{{ grub_pbkdf2_output.stdout | regex_search('(grub\\.pbkdf2\\.sha512\\.[^\\s]+)') }}"
   no_log: "{{ linux_bootloader_disable_nolog | default(false) | ternary(false, true) }}"
 
 - name: "Deploy GRUB password configuration file (/etc/grub.d/01_users)"
-  when: "not _is_wsl"
+  when:
+    - "not _is_wsl"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.template:
     src: "01_users.j2"
     dest: "/etc/grub.d/01_users"
@@ -64,7 +72,9 @@
   notify: "Rebuild GRUB config"
 
 - name: "Ensure GRUB config file has strict permissions"
-  when: "not _is_wsl"
+  when:
+    - "not _is_wsl"
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
   ansible.builtin.file:
     path: "{{ linux_bootloader_grub_cfg_path }}"
     mode: "0600"
@@ -74,6 +84,7 @@
 
 - name: "Debug GRUB password application status (verbosity >=1)"
   when:
+    - "linux_bootloader_password is defined and linux_bootloader_password != ''"
     - "not _is_wsl"
     - "ansible_verbosity >= 1"
   ansible.builtin.debug:

--- a/scripts/tests/test_service_guards.sh
+++ b/scripts/tests/test_service_guards.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Every service task must survive check mode on a host that does not have the
-# unit yet.
+# Every task must survive check mode: `aartool plan` runs the whole hardening
+# playbook with --check.
+#
+# Two hazards are covered here, both reported by users rather than found by
+# reading: a service task whose unit does not exist yet, and a task using async.
 #
 # `aartool plan` runs the hardening playbook with --check. A preview installs
 # nothing, so a role that installs a package and then starts its service hits a
@@ -75,6 +78,32 @@ for f in files:
         else:
             print(f"FAIL  {role}: '{name}' manages '{svc}' with no guard; a preview "
                   f"on a host without that unit will fail")
+            FAIL += 1
+
+# ── async ────────────────────────────────────────────────────────────────────
+#
+# Ansible refuses async under --check with "check mode and async cannot be used
+# on same task". It is a validation error, raised before the task would be
+# skipped for being a command, so the whole run dies rather than previewing.
+# Reported on the AIDE database initialisation.
+for f in files:
+    try:
+        doc = yaml.safe_load(io.open(f, encoding="utf-8"))
+    except Exception:
+        continue
+    if not isinstance(doc, list):
+        continue
+    for t in doc:
+        if not isinstance(t, dict) or "async" not in t:
+            continue
+        when = str(t.get("when", ""))
+        name = str(t.get("name", "?"))[:48]
+        role = f.split("/")[3]
+        if "ansible_check_mode" in when:
+            PASS += 1
+        else:
+            print(f"FAIL  {role}: '{name}' uses async with no check-mode guard; "
+                  f"a preview will die on it, not skip it")
             FAIL += 1
 
 print(f"\n{PASS} passed, {FAIL} failed")


### PR DESCRIPTION
Two more things stopped `aartool plan` before it finished. Both found by running it.

## 1. The reported one: async

```
TASK [linux_aide_ubuntu : Initialize AIDE database (first run or config changed)]
fatal: [localhost]: FAILED! => {"msg": "check mode and async cannot be used on same task."}
```

Ansible refuses `async` under `--check`. It is a **validation** error, raised before the task would have been skipped for being a `command`, so the run dies rather than previewing. This is the only `async` task in the codebase; it is now guarded on `ansible_check_mode` with a note saying what `apply` would do.

## 2. Found while verifying the first

With AIDE fixed, the run got further and died here:

```
TASK [linux_bootloader_password_ubuntu : Fail if GRUB password is not provided via environment variable]
fatal: [localhost]: FAILED!  (censored, no_log)
```

`run-hardening.sh` prints this three lines earlier:

```
[WARN]  LINUX_BOOTLOADER_PASSWORD not set — bootloader_password role will be skipped.
```

**The wrapper's promise and the role's behaviour contradicted each other, and the role won.** A first preview on an ordinary server died on a variable the user had just been told was optional. Only WSL escaped it, because the role skips itself there for unrelated reasons, which is why the earlier WSL reports never reached this task.

Both bootloader roles now skip with an explanation and gate their remaining tasks on the password being set, which is what the wrapper always said happened.

**Behaviour change worth naming:** asking for a GRUB password without providing one no longer aborts the run. Given what the wrapper says it never should have, but anyone relying on the hard failure loses it.

## The result

A full `aartool plan --target localhost` on a fresh Ubuntu host, with systemd:

```
localhost : ok=128  changed=74  unreachable=0  failed=0  skipped=339
TASK [CyberAar | Hardening complete notification]
```

**It reaches the end.** Before this it stopped at the first of these two.

## Guarded

`test_service_guards.sh` now also rejects an async task with no check-mode guard, proven by removing the AIDE guard:

```
FAIL  linux_aide_ubuntu: 'Initialize AIDE database (first run or config ch' uses
      async with no check-mode guard; a preview will die on it, not skip it
```

```
test_aartool 118 · test_docs 195 · test_remediation_map 441 · test_dashboard 34
test_distro 26 · test_versions 17 · test_escaping 14 · test_check_commands 15
test_service_guards 49
909 assertions, 0 failed · ansible-lint clean on the production profile
```
