### PR TITLE
docs: Show HN readiness - tool comparison, security policy, corrected counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,31 @@ supported by the role logic but has no Molecule image yet: treat it as untested.
 
 ---
 
+## How this differs from the tools you already have
+
+These are good tools and `aartool` does not replace them. The gap it is built
+for is the middle of the workflow, between knowing and fixing.
+
+| | what it gives you | what is still on you |
+|---|---|---|
+| [Lynis](https://cisofy.com/lynis/) | a thorough audit and a hardening index | deciding what to do first, and doing it |
+| [OpenSCAP](https://www.open-scap.org/) / CIS-CAT | scanning against a formal profile, and an auditor-shaped report | the report is evidence, not a plan, and the profile is all-or-nothing |
+| [ansible-lockdown](https://github.com/ansible-lockdown), [dev-sec.io](https://dev-sec.io/) | well-maintained remediation roles | knowing which of them this host needs, and what each one breaks |
+
+`aartool` is the loop across that gap: audit, an order to work in, the cost of
+each fix stated before you make it, the change itself, then a diff that proves
+only what you intended moved.
+
+The part that is genuinely different is `explain`. Every finding states what
+closing it breaks, and "not on this machine" is a supported answer. A hardening
+tool that argues one side gets switched off entirely, and its good advice goes
+with it.
+
+If Lynis already tells you what is wrong and you already know what to do about
+it, you do not need this.
+
+---
+
 ## Install
 
 From the package repository, which is what most people want:
@@ -424,19 +449,16 @@ or (at your option) any later version. See [LICENSE](LICENSE) for the full text.
 Written with AI assistance ([Claude](https://claude.ai), Anthropic), and tested
 harder because of it:
 
-- **815 assertions on every commit**, plus Molecule scenarios on Rocky 9 and
+- **911 assertions across the suite**, plus Molecule scenarios on Rocky 9 and
   Ubuntu 22.04.
 - **Every guard here was proven to fail on injected drift before it was
   trusted.** A check that cannot fail is worse than no check.
-- **Run against a live 14-node estate, not only in CI.** One live hardening run
-  found 4 defects that 716 assertions had missed, which is why it is still run
-  on real machines.
+- **Run against a live 15-node estate, not only in CI.** One live hardening run
+  found 4 defects the suite had missed at the time, which is why it is still run
+  on real machines rather than only in CI.
 - **The check and role counts in this README are derived from the tool itself**,
   so the documentation cannot claim a number the code does not produce.
 
 If a claim in this README is not checked by a test, treat it as a bug and open
 an issue.
 
----
-
-*#Cybersecurity #Hardening #AarAct #CyberAar*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,56 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately, not in a public issue.
+
+- **Preferred:** [GitHub private vulnerability reporting](https://github.com/cyberaar/aartool/security/advisories/new)
+- **Email:** security@cyberaar.io
+
+The same address is published at
+[cyberaar.io/.well-known/security.txt](https://cyberaar.io/.well-known/security.txt),
+and the disclosure policy is at
+[cyberaar.io/signaler-vulnerabilite](https://cyberaar.io/signaler-vulnerabilite).
+
+Please include the aartool version (`aartool --version`), the operating system,
+and what an attacker gets. A proof of concept helps, but a clear description of
+the path is enough to start.
+
+We aim to acknowledge within 72 hours and to ship a fix or a documented
+mitigation within 30 days. You will be credited in the release notes unless you
+prefer otherwise.
+
+## Supported versions
+
+The latest release on the `main` branch. Packages served from
+`pkgs.cyberaar.io` track it, so `apt upgrade` and `dnf upgrade` are the fix
+path.
+
+## Scope
+
+In scope: anything in this repository, the published `.deb` and `.rpm`, and the
+signing and distribution of both.
+
+What we consider most serious, given what this tool does:
+
+- Command injection through a hostname, inventory entry, or check output, since
+  much of it is shell that runs as root over SSH.
+- Anything that makes `inspect`, `plan`, `diff` or `surface` modify a host.
+  These are documented as read-only and are relied on that way.
+- `--anonymise` or `--redact` leaving identifying data in a report that is
+  meant to be shareable outside the estate it came from.
+- Report HTML that executes attacker-controlled content from a scanned host,
+  since reports are opened by someone other than the person who ran the audit.
+
+Out of scope: findings that a hardening check does not cover a control you
+expected. Those are feature requests, so open an issue.
+
+## Verifying what you downloaded
+
+Release assets are published with `SHA256SUMS`, and both packages and the
+repository metadata are signed. For a tool that rewrites `sshd_config` and PAM,
+checking the download is not ceremony:
+
+```bash
+sha256sum -c SHA256SUMS --ignore-missing
+```


### PR DESCRIPTION
Prep for a Show HN post. Show HN is currently gated for low-history accounts, so the post is pending a mod request to `hn@ycombinator.com`, but these are worth having regardless.

## How this differs from the tools you already have

The main change. Lynis, OpenSCAP, CIS-CAT, ansible-lockdown and dev-sec were named nowhere in the repo, and "how is this not just Lynis" is the first question any reader asks. Answering it in a comment thread is much weaker than answering it above the fold.

The section is deliberately generous to all of them, frames the gap as the middle of the workflow (between knowing and fixing), points at `explain` as the part that is genuinely different, and ends by saying who should not use this.

## SECURITY.md

A hardening tool with no disclosure policy is a bad look. Contact is `security@cyberaar.io`, matching the `security.txt` already served from cyberaar.io, and the policy link points at the existing `/signaler-vulnerabilite` page. GitHub private vulnerability reporting is now enabled on the repo.

The scope section names what actually matters for this tool rather than boilerplate: command injection through a hostname or check output, anything that makes `inspect` / `plan` / `diff` / `surface` modify a host, `--anonymise` or `--redact` leaving identifying data in a shareable report, and report HTML executing content from a scanned machine.

## Corrected counts

- **Assertions: 815 -> 911.** Measured by running every file in `scripts/tests/` and summing the totals; `test_remediation_map.sh` alone is 441. Also reworded "on every commit" to "across the suite", since the two workflows have path filters and do not both run every time.
- **Estate: 14 -> 15 nodes**, to agree with `docs/AARTOOL.md` and with the "15 of 15 succeeded" line earlier in the same README.

The README says an unchecked claim should be treated as a bug, so these were bugs.

## Removed

The trailing `#Cybersecurity #Hardening #AarAct #CyberAar` line. Reads as social copy on a code repository.

## Deliberately not changed

- The **"Written with AI assistance"** disclosure stays. AI-generated one-offs are the stated reason Show HN was gated in the first place, so disclosing up front next to the evidence (guards proven to fail, live estate runs, counts derived from the tool) is far stronger than having it found in the comments.
- The **"Goal"** paragraph and its sector list. It reads like a brochure next to a README that is concrete everywhere else, but that is a narrative call rather than a docs fix.

## Testing

`scripts/tests/test_docs.sh` passes 195/195. Note it greps every number followed by `roles` or `checks` across the README and `docs/*.md` and asserts it matches disk, so no third-party tool's check count could be quoted in the new section.
