### PR TITLE
test: keep the French check names complete

### DIFF
--- a/.github/workflows/baseline-build.yml
+++ b/.github/workflows/baseline-build.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Reachability waves agree between the engine and advise
         run: bash scripts/tests/test_waves.sh
 
+      - name: Every check carries a French name
+        run: bash scripts/tests/test_french_names.sh
+
       # `aartool plan` runs the playbook with --check, which installs nothing,
       # so a role that installs a package and then starts its service hits a
       # unit that is not there. Reported twice by users, for ufw and for ssh,

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ or (at your option) any later version. See [LICENSE](LICENSE) for the full text.
 Written with AI assistance ([Claude](https://claude.ai), Anthropic), and tested
 harder because of it:
 
-- **1139 assertions across the suite**, plus Molecule scenarios on Rocky 9 and
+- **1371 assertions across the suite**, plus Molecule scenarios on Rocky 9 and
   Ubuntu 22.04.
 - **Every guard here was proven to fail on injected drift before it was
   trusted.** A check that cannot fail is worse than no check.

--- a/ansible-hardening/CHANGELOG.md
+++ b/ansible-hardening/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A guard that every check carries a French name.** `NAME_FR` is rendered by
+  nothing: the tool is English on every surface. It is kept because it is
+  complete, one correct and accented name for every branch of every check, which
+  is the expensive half of a French mode. An asset like that does not die by
+  being deleted, it dies by rotting: a new check family gets `""` because nothing
+  displays it, and a year later the set is 80% complete and worth nothing.
+  `scripts/tests/test_french_names.sh` fails on an empty French name, on the
+  English copied into the French slot, and on its own extraction matching
+  nothing. The copy threshold is derived from the two legitimately identical
+  names in the tree (`SELinux Enforcing`, `SELinux Permissive`), not picked.
+
+### Changed
+
+- `add_result`'s signature comment said its last parameter was `REMEDIATION_FR`,
+  which has not been French for a long time, and said nothing about `NAME_FR`
+  being carried but unrendered. Both documented.
+
 ## [3.5.0]: 2026-08-29
 
 ### Changed

--- a/scripts/aartool-baseline.sh
+++ b/scripts/aartool-baseline.sh
@@ -821,7 +821,21 @@ html_escape() {
   printf '%s' "$s"
 }
 
-# add_result CATEGORY STATUS ID NAME_EN NAME_FR DETAIL REMEDIATION_FR
+# add_result CATEGORY STATUS ID NAME_EN NAME_FR DETAIL REMEDIATION
+#
+# NAME_FR is carried and rendered nowhere. That is deliberate, not an oversight:
+# every output surface (terminal, HTML, JSON, dashboard) is English, and the
+# report used to declare lang="fr" while printing English names either side of a
+# French score label, which read as a bug rather than as a translation.
+#
+# The French names are kept because they are complete and correct, one for every
+# branch of every check, properly accented. That is the expensive half of a
+# French mode and it already exists; deleting it to save a bash array would mean
+# rebuilding it later. scripts/tests/test_french_names.sh keeps it complete, so
+# a French mode stays a switch rather than a project.
+#
+# The last parameter was documented as REMEDIATION_FR and has not been French
+# for a long time; remediation text is English like everything else.
 add_result() {
   local category="$1" status="$2" id="$3" name_en="$4" name_fr="$5"
   local detail="${6:-}" remediation="${7:-}"

--- a/scripts/src/lib/core.sh
+++ b/scripts/src/lib/core.sh
@@ -116,7 +116,21 @@ html_escape() {
   printf '%s' "$s"
 }
 
-# add_result CATEGORY STATUS ID NAME_EN NAME_FR DETAIL REMEDIATION_FR
+# add_result CATEGORY STATUS ID NAME_EN NAME_FR DETAIL REMEDIATION
+#
+# NAME_FR is carried and rendered nowhere. That is deliberate, not an oversight:
+# every output surface (terminal, HTML, JSON, dashboard) is English, and the
+# report used to declare lang="fr" while printing English names either side of a
+# French score label, which read as a bug rather than as a translation.
+#
+# The French names are kept because they are complete and correct, one for every
+# branch of every check, properly accented. That is the expensive half of a
+# French mode and it already exists; deleting it to save a bash array would mean
+# rebuilding it later. scripts/tests/test_french_names.sh keeps it complete, so
+# a French mode stays a switch rather than a project.
+#
+# The last parameter was documented as REMEDIATION_FR and has not been French
+# for a long time; remediation text is English like everything else.
 add_result() {
   local category="$1" status="$2" id="$3" name_en="$4" name_fr="$5"
   local detail="${6:-}" remediation="${7:-}"

--- a/scripts/tests/test_french_names.sh
+++ b/scripts/tests/test_french_names.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Every add_result must carry a French check name.
+#
+# NAME_FR is rendered by nothing today: the tool is English everywhere. It is
+# kept because it is complete, one correct and accented name for every branch of
+# every check, and that is the expensive half of a French mode. An asset like
+# that does not die by being deleted, it dies by rotting: someone adds a check
+# family, passes "" because nothing displays it anyway, and a year later it is
+# 80% complete and worth nothing. Then French becomes a project instead of a
+# switch, and the work already done is wasted.
+#
+# So this guards completeness rather than use. It deliberately does NOT check
+# translation quality, which no test can do.
+#
+# Run: bash scripts/tests/test_french_names.sh
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS+1)); }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL  %s\n' "$*"; }
+
+mapfile -t FILES < <(ls src/checks/*.sh)
+[[ ${#FILES[@]} -ge 8 ]] || { echo "FAIL  only ${#FILES[@]} check files found; the glob is wrong"; exit 1; }
+
+total=0
+for f in "${FILES[@]}"; do
+  # Positional call: add_result CATEGORY STATUS ID NAME_EN NAME_FR ...
+  # Read with the same field order the function uses, from the source, so a call
+  # that spreads over two lines is still seen.
+  while IFS=$'\t' read -r id name_en name_fr; do
+    total=$((total+1))
+    if [[ -z "${name_fr// }" ]]; then
+      bad "$(basename "$f"): $id \"$name_en\" has no French name"
+    elif [[ "$name_fr" == "$name_en" ]]; then
+      # Not automatically wrong: "SELinux Enforcing" and "SELinux Permissive"
+      # are the same in both languages, and those are the only two in the tree
+      # today, at 17 and 18 characters. A longer string identical on both sides
+      # is a copy, which is how this rots quietly. The threshold is set from
+      # those two rather than picked: 20 leaves them room and still catches a
+      # copied sentence.
+      if (( ${#name_en} > 20 )); then
+        bad "$(basename "$f"): $id French name is a copy of the English: \"$name_fr\""
+      else
+        ok
+      fi
+    else
+      ok
+    fi
+  done < <(
+    perl -0777 -ne 'while (/add_result\s+"[^"]*"\s+"[^"]*"\s+"([^"]*)"\s+"([^"]*)"\s+"([^"]*)"/gs) { print "$1\t$2\t$3\n" }' "$f"
+  )
+done
+
+# The extraction itself has to be believable: if the regex stops matching, every
+# assertion above silently passes on an empty set.
+if (( total >= 200 )); then ok; else
+  bad "only $total add_result calls parsed; expected 200+, so the extraction is broken"
+fi
+
+printf '\n%d passed, %d failed  (%d calls checked)\n' "$PASS" "$FAIL" "$total"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Decision: the tool stays English only for now, and the French check names stay in the tree.

## Why keep them

`NAME_FR` is read by nothing. Not the terminal, not the HTML, not the JSON, not the dashboard. It looked like an oversight, so it was worth checking what was actually there before deleting it:

```
231 calls parsed
  0 with an empty French name
135 properly accented
```

```
SYS-01   Distribution supported      ->  Distribution supportée
SYS-03   Pending security updates    ->  Mises à jour de sécurité en attente
```

That is not scaffolding. It is one correct name for every branch of every check, which is the expensive half of a French mode. Deleting it to save a bash array would mean rebuilding it later, and removing the parameter would touch 247 positional call sites, shifting `DETAIL` and `REMEDIATION` left by one across every check file, for no user-visible benefit.

## What actually threatened it

Not existing. **Rotting.** Someone adds a check family, passes `""` because nothing displays it anyway, and in a year the set is 80% complete and worthless. Then French is a project instead of a switch and the work already done is wasted.

`scripts/tests/test_french_names.sh` guards completeness. It does not guard quality, which no test can judge. It fails on:

- an empty French name
- the English copied into the French slot
- **its own extraction matching nothing**, which would otherwise let every assertion pass on an empty set

Each was injected and watched go red before being trusted.

## The threshold is derived, not picked

An identical English and French name is not automatically wrong. The only two in the tree are `SELinux Enforcing` and `SELinux Permissive`, at 17 and 18 characters, so the copy check fires above 20.

The first attempt used 24, and a 24-character copy (`PermitRootLogin disabled`) went straight through while I was proving the guard worked. Deriving the number from the two real cases rather than guessing is what closed it. Worth noting because the first injection I tried also silently failed to match the source, and a guard that cannot fail is worse than no guard.

## Also

`add_result`'s signature comment documented its last parameter as `REMEDIATION_FR`, which has not been French for a long time, and said nothing about `NAME_FR` being carried but unrendered. Both are documented now, so the next reader does not have to work out whether it is dead code or a bug.

1371 assertions, all green. shellcheck clean on both workflows' exact command lines.