### PR TITLE
fix: the remediation plan told you to run a command that fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ or (at your option) any later version. See [LICENSE](LICENSE) for the full text.
 Written with AI assistance ([Claude](https://claude.ai), Anthropic), and tested
 harder because of it:
 
-- **1371 assertions across the suite**, plus Molecule scenarios on Rocky 9 and
+- **1374 assertions across the suite**, plus Molecule scenarios on Rocky 9 and
   Ubuntu 22.04.
 - **Every guard here was proven to fail on injected drift before it was
   trusted.** A check that cannot fail is worse than no check.

--- a/ansible-hardening/CHANGELOG.md
+++ b/ansible-hardening/CHANGELOG.md
@@ -20,6 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing. The copy threshold is derived from the two legitimately identical
   names in the tree (`SELinux Enforcing`, `SELinux Permissive`), not picked.
 
+### Fixed
+
+- **The report told you to run a command that fails.** The remediation plan read
+  *"Ajoutez `--check --diff` pour simuler"*: French, in an English document, and
+  wrong. `--check` and `--diff` are `ansible-playbook` flags, while every command
+  in that table is `aartool apply`, which rejects them outright. It now says to
+  preview with `aartool plan`. The Tags column advertised `--tags` next to a
+  command using `--only`; both say `--only` now.
+- Two more French strings in the same section: the `Commande aartool` column
+  header and a bilingual `Tout corriger en une commande / Fix everything in one
+  run` button label.
+- **The palette port missed every colour written as `rgba()`.**
+  `rgba(0,194,168,...)` is the old teal and `rgba(126,211,72,...)` the old lime,
+  so borders, glows and table hovers stayed off-palette and did not follow the
+  print theme. Sixteen literals replaced by tokens, with print variants.
+
 ### Changed
 
 - `add_result`'s signature comment said its last parameter was `REMEDIATION_FR`,

--- a/scripts/aartool-baseline.sh
+++ b/scripts/aartool-baseline.sh
@@ -2590,7 +2590,7 @@ _render_html() {
     ANSIBLE_PLAN_HTML+="<tr class='plan-row'>"
     ANSIBLE_PLAN_HTML+="<td class='plan-desc'><strong>$_desc</strong></td>"
     ANSIBLE_PLAN_HTML+="<td class='plan-role'><code>$_role_r</code><br><small>Ubuntu: <code>$_role_u</code></small></td>"
-    ANSIBLE_PLAN_HTML+="<td class='plan-tags'><span class='tag-badge'>--tags $_tags</span></td>"
+    ANSIBLE_PLAN_HTML+="<td class='plan-tags'><span class='tag-badge'>--only $_tags</span></td>"
     ANSIBLE_PLAN_HTML+="<td class='plan-cmd'><code>aartool apply --target $_tgt --only $_tags</code></td>"
     ANSIBLE_PLAN_HTML+="</tr>"
   done
@@ -2655,10 +2655,28 @@ cat > "$HTML_OUT" <<HTMLEOF
   /* Tinted fills. Defined per theme rather than derived, because color-mix()
      is not safe to depend on for a file whose whole point is opening on a
      machine we know nothing about. */
-  --accent-dim: rgba(0, 229, 176, .15);
-  --pass-bg:    rgba(0, 229, 176, .08);
-  --warn-bg:    rgba(245, 158, 11, .08);
-  --fail-bg:    rgba(239, 68, 68, .08);
+  --accent-dim:   rgba(0, 229, 176, .15);
+  --pass-bg:      rgba(0, 229, 176, .08);
+  --warn-bg:      rgba(245, 158, 11, .08);
+  --fail-bg:      rgba(239, 68, 68, .08);
+
+  /* Decorative alphas. These existed as rgba() literals of the OLD palette
+     (0,194,168 = the old teal, 126,211,72 = the old lime, 13,27,62 and
+     19,34,68 = the old navies), which the first port missed because it only
+     looked for hex. A colour written in decimal is still a colour outside the
+     palette: it does not follow @media print, so borders and glows stayed on
+     the dark theme on paper. */
+  --accent-glow:  rgba(0, 229, 176, .30);
+  --accent-wash:  rgba(0, 229, 176, .08);
+  --accent-soft:  rgba(0, 229, 176, .06);
+  --accent-hover: rgba(0, 229, 176, .25);
+  --pass-edge:    rgba(0, 229, 176, .25);
+  --warn-edge:    rgba(245, 158, 11, .25);
+  --fail-edge:    rgba(239, 68, 68, .25);
+  --panel:        rgba(13, 21, 38, .90);
+  --panel-hover:  rgba(17, 28, 48, .95);
+  --hairline:     rgba(255, 255, 255, .05);
+  --shadow:       rgba(0, 0, 0, .40);
 
   /* ── Aliases ───────────────────────────────────────────────────────────────
      The rules below this block are written against these names. Custom
@@ -2699,8 +2717,8 @@ body::before {
   position: fixed;
   inset: 0;
   background:
-    radial-gradient(ellipse 80% 60% at 50% -10%, rgba(0,194,168,.08) 0%, transparent 70%),
-    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(126,211,72,.05) 0%, transparent 60%);
+    radial-gradient(ellipse 80% 60% at 50% -10%, var(--accent-wash) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 40% at 100% 100%, var(--accent-soft) 0%, transparent 60%);
   background-attachment: fixed;
   opacity: 0.04;
   pointer-events: none;
@@ -2729,13 +2747,13 @@ header {
   top: 0;
   z-index: 100;
   backdrop-filter: blur(12px);
-  box-shadow: 0 4px 30px rgba(0,0,0,.4);
+  box-shadow: 0 4px 30px var(--shadow);
 }
 .header-logo img {
   height: 54px;
   width: auto;
   display: block;
-  filter: drop-shadow(0 2px 8px rgba(0,194,168,.3));
+  filter: drop-shadow(0 2px 8px var(--accent-glow));
 }
 .header-title {
   display: flex;
@@ -2747,7 +2765,7 @@ header {
   font-size: 1.3rem;
   font-weight: 700;
   letter-spacing: -.01em;
-  color: #fff;
+  color: var(--text);
   line-height: 1.2;
 }
 .header-title .subtitle {
@@ -2770,7 +2788,7 @@ header {
   display: inline-block;
   background: var(--ca-teal-dim);
   color: var(--ca-teal);
-  border: 1px solid rgba(0,194,168,.3);
+  border: 1px solid var(--accent-glow);
   border-radius: 20px;
   padding: .1rem .6rem;
   font-size: .68rem;
@@ -2800,7 +2818,7 @@ header {
   right: -5%;
   width: 220px;
   height: 220px;
-  background: radial-gradient(circle, rgba(0,194,168,.07) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--accent-soft) 0%, transparent 70%);
   pointer-events: none;
 }
 .score-ring {
@@ -2848,7 +2866,7 @@ header {
   display: flex;
   align-items: center;
   gap: .5rem;
-  background: rgba(255,255,255,.04);
+  background: var(--hairline);
   border: 1px solid var(--border);
   border-radius: 20px;
   padding: .3rem .9rem;
@@ -2874,7 +2892,7 @@ header {
   margin-bottom: .4rem;
 }
 .progress {
-  background: rgba(255,255,255,.06);
+  background: var(--hairline);
   border-radius: 99px;
   height: 6px;
   overflow: hidden;
@@ -2923,7 +2941,7 @@ header {
   font-size: .85rem;
 }
 .results-table thead th {
-  background: rgba(13,27,62,.9);
+  background: var(--panel);
   padding: .6rem 1rem;
   text-align: left;
   font-family: var(--font-mono);
@@ -2940,7 +2958,7 @@ header {
   background: var(--card);
   transition: background .15s;
 }
-.results-table tbody tr:hover { background: rgba(19,34,68,.95); }
+.results-table tbody tr:hover { background: var(--panel-hover); }
 .results-table tbody tr + tr td { border-top: 1px solid var(--border); }
 .results-table td {
   padding: .75rem 1rem;
@@ -3000,9 +3018,9 @@ header {
   letter-spacing: .04em;
   white-space: nowrap;
 }
-.badge.pass { background: var(--pass-bg); color: var(--pass); border: 1px solid rgba(34,197,94,.25); }
-.badge.warn { background: var(--warn-bg); color: var(--warn); border: 1px solid rgba(245,158,11,.25); }
-.badge.fail { background: var(--fail-bg); color: var(--fail); border: 1px solid rgba(239,68,68,.25); }
+.badge.pass { background: var(--pass-bg); color: var(--pass); border: 1px solid var(--pass-edge); }
+.badge.warn { background: var(--warn-bg); color: var(--warn); border: 1px solid var(--warn-edge); }
+.badge.fail { background: var(--fail-bg); color: var(--fail); border: 1px solid var(--fail-edge); }
 
 /* ── Category label ──────────────────────────────────────────────────── */
 .cat-label {
@@ -3010,7 +3028,7 @@ header {
   font-size: .68rem;
   font-family: var(--font-mono);
   color: var(--muted);
-  background: rgba(255,255,255,.04);
+  background: var(--hairline);
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: .1rem .4rem;
@@ -3068,14 +3086,26 @@ footer {
     --danger:    #b91c1c;   /* 5.9:1 on white; #ef4444 is 3.3:1 */
     --info:      #1d4ed8;
 
-    --accent-dim: rgba(15, 118, 110, .10);
-    --pass-bg:    rgba(15, 118, 110, .07);
-    --warn-bg:    rgba(180, 83, 9, .07);
-    --fail-bg:    rgba(185, 28, 28, .07);
+    --accent-dim:   rgba(15, 118, 110, .10);
+    --pass-bg:      rgba(15, 118, 110, .07);
+    --warn-bg:      rgba(180, 83, 9, .07);
+    --fail-bg:      rgba(185, 28, 28, .07);
+
+    --accent-glow:  rgba(15, 118, 110, .25);
+    --accent-wash:  rgba(15, 118, 110, .06);
+    --accent-soft:  rgba(15, 118, 110, .05);
+    --accent-hover: rgba(15, 118, 110, .12);
+    --pass-edge:    rgba(15, 118, 110, .35);
+    --warn-edge:    rgba(180, 83, 9, .35);
+    --fail-edge:    rgba(185, 28, 28, .35);
+    --panel:        #f8fafc;
+    --panel-hover:  #f1f5f9;
+    --hairline:     rgba(0, 0, 0, .08);
+    --shadow:       rgba(0, 0, 0, .10);
   }
 
   body {
-    background: #fff;
+    background: var(--bg);
     color: var(--text);
     font-size: 10pt;
     line-height: 1.45;
@@ -3116,7 +3146,7 @@ footer {
   margin-bottom: 1rem;
 }
 .plan-table thead th {
-  background: rgba(13,27,62,.9);
+  background: var(--panel);
   padding: .6rem 1rem;
   text-align: left;
   font-family: var(--font-mono);
@@ -3130,7 +3160,7 @@ footer {
 .plan-table thead th:first-child { border-radius: var(--radius) 0 0 0; }
 .plan-table thead th:last-child  { border-radius: 0 var(--radius) 0 0; }
 .plan-table tbody tr { background: var(--card); transition: background .15s; }
-.plan-table tbody tr:hover { background: rgba(19,34,68,.95); }
+.plan-table tbody tr:hover { background: var(--panel-hover); }
 .plan-table tbody tr + tr td { border-top: 1px solid var(--border); }
 .plan-table td { padding: .75rem 1rem; vertical-align: top; }
 .plan-table tbody tr:last-child td:first-child { border-radius: 0 0 0 var(--radius); }
@@ -3143,7 +3173,7 @@ footer {
   display: inline-block;
   background: var(--ca-teal-dim);
   color: var(--ca-teal);
-  border: 1px solid rgba(0,194,168,.3);
+  border: 1px solid var(--accent-glow);
   border-radius: 4px;
   padding: .15rem .5rem;
   font-family: var(--font-mono);
@@ -3156,8 +3186,8 @@ footer {
   word-break: break-all;
 }
 .consolidated-cmd {
-  background: rgba(126,211,72,.06);
-  border: 1px solid rgba(126,211,72,.2);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-glow);
   border-radius: var(--radius);
   padding: 1rem 1.2rem;
   margin-top: 1rem;
@@ -3178,7 +3208,7 @@ footer {
 .copy-btn {
   float: right;
   background: var(--ca-teal-dim);
-  border: 1px solid rgba(0,194,168,.3);
+  border: 1px solid var(--accent-glow);
   color: var(--ca-teal);
   border-radius: 6px;
   padding: .2rem .6rem;
@@ -3187,7 +3217,7 @@ footer {
   font-family: var(--font-body);
   margin-top: -.1rem;
 }
-.copy-btn:hover { background: rgba(0,194,168,.25); }
+.copy-btn:hover { background: var(--accent-hover); }
 
 </style>
 </head>
@@ -3260,7 +3290,8 @@ ${HTML_ROWS}
   <div class="section-title">Remediation Plan</div>
   <p style="font-size:.85rem;color:var(--muted);margin-bottom:1rem;">
     A targeted command for each failing or warning check.
-    Ajoutez <code style="color:var(--ca-teal)">--check --diff</code> pour simuler.
+    Preview any of them with <code style="color:var(--ca-teal)">aartool plan</code>,
+    same arguments. It changes nothing.
   </p>
   <table class="plan-table">
     <thead>
@@ -3268,7 +3299,7 @@ ${HTML_ROWS}
         <th>Issue</th>
         <th>Ansible Role</th>
         <th>Tags</th>
-        <th>Commande aartool</th>
+        <th>Command</th>
       </tr>
     </thead>
     <tbody>
@@ -3277,7 +3308,7 @@ ${ANSIBLE_PLAN_HTML}
   </table>
   <div class="consolidated-cmd">
     <button class="copy-btn" onclick="navigator.clipboard.writeText(this.nextElementSibling.textContent.trim()).then(()=>{this.textContent='✅ Copied';setTimeout(()=>this.textContent='📋 Copy',1500)})">📋 Copy</button>
-    <span class="cmd-label">Tout corriger en une commande / Fix everything in one run</span>
+    <span class="cmd-label">Fix everything in one run</span>
     ${ANSIBLE_CONSOLIDATED_CMD}
   </div>
 </div>

--- a/scripts/src/renderers/html.sh
+++ b/scripts/src/renderers/html.sh
@@ -95,7 +95,7 @@ _render_html() {
     ANSIBLE_PLAN_HTML+="<tr class='plan-row'>"
     ANSIBLE_PLAN_HTML+="<td class='plan-desc'><strong>$_desc</strong></td>"
     ANSIBLE_PLAN_HTML+="<td class='plan-role'><code>$_role_r</code><br><small>Ubuntu: <code>$_role_u</code></small></td>"
-    ANSIBLE_PLAN_HTML+="<td class='plan-tags'><span class='tag-badge'>--tags $_tags</span></td>"
+    ANSIBLE_PLAN_HTML+="<td class='plan-tags'><span class='tag-badge'>--only $_tags</span></td>"
     ANSIBLE_PLAN_HTML+="<td class='plan-cmd'><code>aartool apply --target $_tgt --only $_tags</code></td>"
     ANSIBLE_PLAN_HTML+="</tr>"
   done
@@ -160,10 +160,28 @@ cat > "$HTML_OUT" <<HTMLEOF
   /* Tinted fills. Defined per theme rather than derived, because color-mix()
      is not safe to depend on for a file whose whole point is opening on a
      machine we know nothing about. */
-  --accent-dim: rgba(0, 229, 176, .15);
-  --pass-bg:    rgba(0, 229, 176, .08);
-  --warn-bg:    rgba(245, 158, 11, .08);
-  --fail-bg:    rgba(239, 68, 68, .08);
+  --accent-dim:   rgba(0, 229, 176, .15);
+  --pass-bg:      rgba(0, 229, 176, .08);
+  --warn-bg:      rgba(245, 158, 11, .08);
+  --fail-bg:      rgba(239, 68, 68, .08);
+
+  /* Decorative alphas. These existed as rgba() literals of the OLD palette
+     (0,194,168 = the old teal, 126,211,72 = the old lime, 13,27,62 and
+     19,34,68 = the old navies), which the first port missed because it only
+     looked for hex. A colour written in decimal is still a colour outside the
+     palette: it does not follow @media print, so borders and glows stayed on
+     the dark theme on paper. */
+  --accent-glow:  rgba(0, 229, 176, .30);
+  --accent-wash:  rgba(0, 229, 176, .08);
+  --accent-soft:  rgba(0, 229, 176, .06);
+  --accent-hover: rgba(0, 229, 176, .25);
+  --pass-edge:    rgba(0, 229, 176, .25);
+  --warn-edge:    rgba(245, 158, 11, .25);
+  --fail-edge:    rgba(239, 68, 68, .25);
+  --panel:        rgba(13, 21, 38, .90);
+  --panel-hover:  rgba(17, 28, 48, .95);
+  --hairline:     rgba(255, 255, 255, .05);
+  --shadow:       rgba(0, 0, 0, .40);
 
   /* ── Aliases ───────────────────────────────────────────────────────────────
      The rules below this block are written against these names. Custom
@@ -204,8 +222,8 @@ body::before {
   position: fixed;
   inset: 0;
   background:
-    radial-gradient(ellipse 80% 60% at 50% -10%, rgba(0,194,168,.08) 0%, transparent 70%),
-    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(126,211,72,.05) 0%, transparent 60%);
+    radial-gradient(ellipse 80% 60% at 50% -10%, var(--accent-wash) 0%, transparent 70%),
+    radial-gradient(ellipse 60% 40% at 100% 100%, var(--accent-soft) 0%, transparent 60%);
   background-attachment: fixed;
   opacity: 0.04;
   pointer-events: none;
@@ -234,13 +252,13 @@ header {
   top: 0;
   z-index: 100;
   backdrop-filter: blur(12px);
-  box-shadow: 0 4px 30px rgba(0,0,0,.4);
+  box-shadow: 0 4px 30px var(--shadow);
 }
 .header-logo img {
   height: 54px;
   width: auto;
   display: block;
-  filter: drop-shadow(0 2px 8px rgba(0,194,168,.3));
+  filter: drop-shadow(0 2px 8px var(--accent-glow));
 }
 .header-title {
   display: flex;
@@ -252,7 +270,7 @@ header {
   font-size: 1.3rem;
   font-weight: 700;
   letter-spacing: -.01em;
-  color: #fff;
+  color: var(--text);
   line-height: 1.2;
 }
 .header-title .subtitle {
@@ -275,7 +293,7 @@ header {
   display: inline-block;
   background: var(--ca-teal-dim);
   color: var(--ca-teal);
-  border: 1px solid rgba(0,194,168,.3);
+  border: 1px solid var(--accent-glow);
   border-radius: 20px;
   padding: .1rem .6rem;
   font-size: .68rem;
@@ -305,7 +323,7 @@ header {
   right: -5%;
   width: 220px;
   height: 220px;
-  background: radial-gradient(circle, rgba(0,194,168,.07) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--accent-soft) 0%, transparent 70%);
   pointer-events: none;
 }
 .score-ring {
@@ -353,7 +371,7 @@ header {
   display: flex;
   align-items: center;
   gap: .5rem;
-  background: rgba(255,255,255,.04);
+  background: var(--hairline);
   border: 1px solid var(--border);
   border-radius: 20px;
   padding: .3rem .9rem;
@@ -379,7 +397,7 @@ header {
   margin-bottom: .4rem;
 }
 .progress {
-  background: rgba(255,255,255,.06);
+  background: var(--hairline);
   border-radius: 99px;
   height: 6px;
   overflow: hidden;
@@ -428,7 +446,7 @@ header {
   font-size: .85rem;
 }
 .results-table thead th {
-  background: rgba(13,27,62,.9);
+  background: var(--panel);
   padding: .6rem 1rem;
   text-align: left;
   font-family: var(--font-mono);
@@ -445,7 +463,7 @@ header {
   background: var(--card);
   transition: background .15s;
 }
-.results-table tbody tr:hover { background: rgba(19,34,68,.95); }
+.results-table tbody tr:hover { background: var(--panel-hover); }
 .results-table tbody tr + tr td { border-top: 1px solid var(--border); }
 .results-table td {
   padding: .75rem 1rem;
@@ -505,9 +523,9 @@ header {
   letter-spacing: .04em;
   white-space: nowrap;
 }
-.badge.pass { background: var(--pass-bg); color: var(--pass); border: 1px solid rgba(34,197,94,.25); }
-.badge.warn { background: var(--warn-bg); color: var(--warn); border: 1px solid rgba(245,158,11,.25); }
-.badge.fail { background: var(--fail-bg); color: var(--fail); border: 1px solid rgba(239,68,68,.25); }
+.badge.pass { background: var(--pass-bg); color: var(--pass); border: 1px solid var(--pass-edge); }
+.badge.warn { background: var(--warn-bg); color: var(--warn); border: 1px solid var(--warn-edge); }
+.badge.fail { background: var(--fail-bg); color: var(--fail); border: 1px solid var(--fail-edge); }
 
 /* ── Category label ──────────────────────────────────────────────────── */
 .cat-label {
@@ -515,7 +533,7 @@ header {
   font-size: .68rem;
   font-family: var(--font-mono);
   color: var(--muted);
-  background: rgba(255,255,255,.04);
+  background: var(--hairline);
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: .1rem .4rem;
@@ -573,14 +591,26 @@ footer {
     --danger:    #b91c1c;   /* 5.9:1 on white; #ef4444 is 3.3:1 */
     --info:      #1d4ed8;
 
-    --accent-dim: rgba(15, 118, 110, .10);
-    --pass-bg:    rgba(15, 118, 110, .07);
-    --warn-bg:    rgba(180, 83, 9, .07);
-    --fail-bg:    rgba(185, 28, 28, .07);
+    --accent-dim:   rgba(15, 118, 110, .10);
+    --pass-bg:      rgba(15, 118, 110, .07);
+    --warn-bg:      rgba(180, 83, 9, .07);
+    --fail-bg:      rgba(185, 28, 28, .07);
+
+    --accent-glow:  rgba(15, 118, 110, .25);
+    --accent-wash:  rgba(15, 118, 110, .06);
+    --accent-soft:  rgba(15, 118, 110, .05);
+    --accent-hover: rgba(15, 118, 110, .12);
+    --pass-edge:    rgba(15, 118, 110, .35);
+    --warn-edge:    rgba(180, 83, 9, .35);
+    --fail-edge:    rgba(185, 28, 28, .35);
+    --panel:        #f8fafc;
+    --panel-hover:  #f1f5f9;
+    --hairline:     rgba(0, 0, 0, .08);
+    --shadow:       rgba(0, 0, 0, .10);
   }
 
   body {
-    background: #fff;
+    background: var(--bg);
     color: var(--text);
     font-size: 10pt;
     line-height: 1.45;
@@ -621,7 +651,7 @@ footer {
   margin-bottom: 1rem;
 }
 .plan-table thead th {
-  background: rgba(13,27,62,.9);
+  background: var(--panel);
   padding: .6rem 1rem;
   text-align: left;
   font-family: var(--font-mono);
@@ -635,7 +665,7 @@ footer {
 .plan-table thead th:first-child { border-radius: var(--radius) 0 0 0; }
 .plan-table thead th:last-child  { border-radius: 0 var(--radius) 0 0; }
 .plan-table tbody tr { background: var(--card); transition: background .15s; }
-.plan-table tbody tr:hover { background: rgba(19,34,68,.95); }
+.plan-table tbody tr:hover { background: var(--panel-hover); }
 .plan-table tbody tr + tr td { border-top: 1px solid var(--border); }
 .plan-table td { padding: .75rem 1rem; vertical-align: top; }
 .plan-table tbody tr:last-child td:first-child { border-radius: 0 0 0 var(--radius); }
@@ -648,7 +678,7 @@ footer {
   display: inline-block;
   background: var(--ca-teal-dim);
   color: var(--ca-teal);
-  border: 1px solid rgba(0,194,168,.3);
+  border: 1px solid var(--accent-glow);
   border-radius: 4px;
   padding: .15rem .5rem;
   font-family: var(--font-mono);
@@ -661,8 +691,8 @@ footer {
   word-break: break-all;
 }
 .consolidated-cmd {
-  background: rgba(126,211,72,.06);
-  border: 1px solid rgba(126,211,72,.2);
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-glow);
   border-radius: var(--radius);
   padding: 1rem 1.2rem;
   margin-top: 1rem;
@@ -683,7 +713,7 @@ footer {
 .copy-btn {
   float: right;
   background: var(--ca-teal-dim);
-  border: 1px solid rgba(0,194,168,.3);
+  border: 1px solid var(--accent-glow);
   color: var(--ca-teal);
   border-radius: 6px;
   padding: .2rem .6rem;
@@ -692,7 +722,7 @@ footer {
   font-family: var(--font-body);
   margin-top: -.1rem;
 }
-.copy-btn:hover { background: rgba(0,194,168,.25); }
+.copy-btn:hover { background: var(--accent-hover); }
 
 </style>
 </head>
@@ -765,7 +795,8 @@ ${HTML_ROWS}
   <div class="section-title">Remediation Plan</div>
   <p style="font-size:.85rem;color:var(--muted);margin-bottom:1rem;">
     A targeted command for each failing or warning check.
-    Ajoutez <code style="color:var(--ca-teal)">--check --diff</code> pour simuler.
+    Preview any of them with <code style="color:var(--ca-teal)">aartool plan</code>,
+    same arguments. It changes nothing.
   </p>
   <table class="plan-table">
     <thead>
@@ -773,7 +804,7 @@ ${HTML_ROWS}
         <th>Issue</th>
         <th>Ansible Role</th>
         <th>Tags</th>
-        <th>Commande aartool</th>
+        <th>Command</th>
       </tr>
     </thead>
     <tbody>
@@ -782,7 +813,7 @@ ${ANSIBLE_PLAN_HTML}
   </table>
   <div class="consolidated-cmd">
     <button class="copy-btn" onclick="navigator.clipboard.writeText(this.nextElementSibling.textContent.trim()).then(()=>{this.textContent='✅ Copied';setTimeout(()=>this.textContent='📋 Copy',1500)})">📋 Copy</button>
-    <span class="cmd-label">Tout corriger en une commande / Fix everything in one run</span>
+    <span class="cmd-label">Fix everything in one run</span>
     ${ANSIBLE_CONSOLIDATED_CMD}
   </div>
 </div>

--- a/scripts/tests/test_dashboard.sh
+++ b/scripts/tests/test_dashboard.sh
@@ -151,6 +151,39 @@ if command -v node >/dev/null 2>&1; then
     printf '%s\n%s\n' "$subres" "$cssres" | grep -v '^$' | sed 's/^/        /'
   fi
 
+  # ── No colour outside the token block ─────────────────────────────────────
+  # The palette port replaced the hex literals and missed the same colours
+  # written as rgba(): rgba(0,194,168,...) is the old teal and
+  # rgba(126,211,72,...) the old lime, so borders, glows and table hovers stayed
+  # off-palette and did not follow @media print. A colour in decimal is still a
+  # colour outside the palette.
+  #
+  # Every colour must be declared in :root or @media print and used through
+  # var(). Anything else is a literal somebody will forget to theme.
+  # Scanned line by line over the ORIGINAL file, so a reported line number is
+  # the line to open. An earlier version blanked the token blocks first and lost
+  # 111 lines doing it, then still 10 after a fix, and pointed at line 173 for a
+  # problem on line 255. A guard that sends you to the wrong line is only
+  # slightly better than no guard.
+  #
+  # Skipped: the :root blocks, where colours are declared, and comments, which
+  # name colours in prose and cannot reach a document.
+  strays=$(perl -ne '
+      if (/:root\s*\{/)      { $root = 1 }
+      if ($root && /\}/)      { $root = 0; next }
+      next if $root;
+      if (m{/\*})            { $cmt = 1 }
+      my $was = $cmt;
+      if ($cmt && m{\*/})     { $cmt = 0 }
+      next if $was;
+      next if /^\s*#/;
+      print "$.:$_" if /#[0-9a-fA-F]{3,8}\b|rgba?\([0-9]/;
+    ' "$RENDERER" || true)
+  if [[ -z "$strays" ]]; then ok; else
+    bad "colour literals outside the token block; they cannot follow the print theme:"
+    printf '%s\n' "$strays" | head -12 | sed 's/^/        /'
+  fi
+
   # ── The report is in one language, and it is English ──────────────────────
   # It declared lang="fr" and printed CRITIQUE / FAIBLE / MOYEN as the score
   # label, either side of English check names and English remediation, and
@@ -160,11 +193,45 @@ if command -v node >/dev/null 2>&1; then
   lang=$(grep -oP '<html lang="\K[a-z]+' "$RENDERER" | head -1)
   [[ "$lang" == "en" ]] && ok || bad "the HTML report declares lang=\"$lang\"; its content is English"
 
-  frstr=$(grep -nP '"(CRITIQUE|FAIBLE|MOYEN|EXCELLENT)"|\b(Auditez|Installez|Initialisez|Corrigez|Vérifiez)\b' \
-          "$RENDERER" src/checks/*.sh 2>/dev/null || true)
+  # The first version of this check was a denylist of five French verbs, and it
+  # missed "Ajoutez --check --diff pour simuler", a French column header, and a
+  # bilingual button label, all of which a reader found in the first report they
+  # opened. A denylist only ever catches the words you already knew about.
+  #
+  # Look at the prose instead: strip CSS, JS and shell interpolation, take the
+  # text a reader actually sees, and flag common French function words. Those do
+  # not appear in English text, and unlike accents they survive an author
+  # writing without them.
+  fr_words='pour|une|dans|avec|sur|tout|toute|cette|aux|les|des|est|sont|vers|selon|ainsi|chaque|leur|entre|sans|plus|corriger|simuler|commande|fichier|serveur|noyau|mot de passe'
+  # Delimiters matter here: s{...} treats } as the closing delimiter, so a
+  # [^}] class inside it ends the pattern early and perl dies. The first version
+  # did exactly that, printed a regex error, produced an empty $prose, and the
+  # check reported ok on nothing. Hence the length assertion below.
+  prose=$(perl -0777 -ne '
+      s|<style.*?</style>||gs; s|<script.*?</script>||gs;   # not prose
+      s|\$\{[^}]*\}| |g;                                    # shell interpolation
+      s|<[^>]+>| |g;                                        # tags
+      print;
+    ' "$RENDERER")
+
+  # A guard reading an empty string passes forever. Assert there is prose to
+  # search before believing the search found nothing.
+  if (( ${#prose} > 2000 )); then ok; else
+    bad "extracted only ${#prose} characters of prose from $RENDERER; the extraction is broken, so the French check below proves nothing"
+  fi
+
+  frstr=$(printf '%s' "$prose" | grep -oiP "\\b($fr_words)\\b" | sort | uniq -c | sort -rn || true)
   if [[ -z "$frstr" ]]; then ok; else
-    bad "French strings reach the report, which is otherwise English:"
+    bad "French words appear in the report's prose, which is otherwise English:"
     printf '%s\n' "$frstr" | sed 's/^/        /'
+  fi
+
+  # The check families are the other place French reached a reader.
+  frchk=$(grep -nP '"(CRITIQUE|FAIBLE|MOYEN|EXCELLENT)"|\b(Auditez|Installez|Initialisez|Corrigez|Vérifiez|Ajoutez|Configurez|Activez|Désactivez)\b' \
+          src/checks/*.sh 2>/dev/null || true)
+  if [[ -z "$frchk" ]]; then ok; else
+    bad "French strings in check output:"
+    printf '%s\n' "$frchk" | sed 's/^/        /'
   fi
 
   # ── The JSON root key was renamed cyberaar_baseline -> aartool ────────────


### PR DESCRIPTION
Found by reading a generated report, which is the only way any of this surfaces.

## The line

> A targeted command for each failing or warning check. **Ajoutez `--check --diff` pour simuler.**

Two problems in one sentence.

It is French in an English document. And `--check` / `--diff` are `ansible-playbook` flags, while every command in that table is `aartool apply`:

```
$ aartool apply --target localhost --check
[ERROR] Unknown option for apply: --check. Try 'aartool apply --help'.
```

So the report's own instruction did not work. Everything goes through aartool now, and the way to preview is `aartool plan` with the same arguments. That is what it says.

Two more French strings in the same block: the `Commande aartool` column header, and a bilingual `Tout corriger en une commande / Fix everything in one run` label. The Tags column also advertised `--tags`, the ansible-playbook flag, next to a command using `--only`. Both say `--only` now.

## Why the guard I added yesterday missed it

It was a denylist of five French verbs, and `Ajoutez` was not one of them. **A denylist only catches the words you already knew about.**

It reads the report's prose now: CSS, JS and shell interpolation stripped, then common French function words (`pour`, `une`, `tout`, `commande`, `simuler`, …). Those do not occur in English text, and unlike accents they survive an author typing without them.

## The same class of miss, in the palette

Chasing this turned up that the palette port replaced hex literals and left the **identical colours written as `rgba()`**:

```
rgba(0,194,168,…)   the old teal      5 uses
rgba(126,211,72,…)  the old lime      3 uses
rgba(13,27,62,…)    the old navy      2 uses
rgba(19,34,68,…)    old navy-mid      2 uses
```

A colour in decimal is still a colour outside the palette: those borders, glows and table hovers could not follow `@media print`. Sixteen literals are tokens now, with print variants.

## Three guards, each proven against its bug

- French words in the report's prose
- colour literals outside the token block, **in any notation**
- the prose extraction returning nothing, because a guard reading an empty string passes forever

That last one is not hypothetical. My first prose extractor used `s{…}` with a `[^}]` class inside it, so perl closed the pattern early, died with a regex error, and the check reported **ok** on an empty string. The line numbers were wrong twice too, pointing at 173 for a problem on 255, before I rewrote it as a line-by-line scan of the original file. Both are the same failure the repo already warns about: a check that cannot fail is worse than no check.

1374 assertions, all green. shellcheck clean on both workflows' command lines.