### PR TITLE
fix: English in the fields the report renders, and guard the category

### DIFF
--- a/scripts/aartool-baseline.sh
+++ b/scripts/aartool-baseline.sh
@@ -940,7 +940,7 @@ case "$_SYS_PKG" in
       add_result "System" "PASS" "SYS-03" "No pending security updates" "Système à jour" "0 packages" ""
     else
       add_result "System" "FAIL" "SYS-03" "Pending security updates" "Mises à jour en attente" "$PENDING package(s)" \
-        "Appliquez: '$_SYS_PKG update --security -y'"
+        "Apply: '$_SYS_PKG update --security -y'"
     fi ;;
   apt-get)
     # Scoped to SECURITY updates, like the dnf and zypper branches above it.
@@ -964,7 +964,7 @@ case "$_SYS_PKG" in
     else
       add_result "System" "FAIL" "SYS-03" "Pending security updates" "Mises à jour de sécurité en attente" \
         "${PENDING} security (${_SYS_APT_TOTAL} total pending)" \
-        "Appliquez: 'apt-get upgrade -y' (ou laissez unattended-upgrades le faire)"
+        "Apply: 'apt-get upgrade -y', or let unattended-upgrades do it"
     fi ;;
   zypper)
     # list-patches --category security is the SUSE equivalent of --security.
@@ -974,7 +974,7 @@ case "$_SYS_PKG" in
       add_result "System" "PASS" "SYS-03" "No pending security patches" "Système à jour" "0 patches" ""
     else
       add_result "System" "FAIL" "SYS-03" "Pending security patches" "Correctifs en attente" "$PENDING patch(es)" \
-        "Appliquez: 'zypper patch --category security'"
+        "Apply: 'zypper patch --category security'"
     fi ;;
   pacman)
     # Rolling release: there is no security-only channel, so this is all updates.
@@ -992,7 +992,7 @@ case "$_SYS_PKG" in
       add_result "System" "PASS" "SYS-03" "No pending updates" "Système à jour" "0 packages" ""
     else
       add_result "System" "WARN" "SYS-03" "Pending updates" "Mises à jour en attente" "$PENDING package(s)" \
-        "Appliquez: 'apk upgrade'"
+        "Apply: 'apk upgrade'"
     fi ;;
   none)
     add_result "System" "WARN" "SYS-03" "No package manager found" "Aucun gestionnaire de paquets" \
@@ -1910,7 +1910,7 @@ if [[ "$IPV6_RA" == "0" ]]; then
   add_result "Network" "PASS" "NET-10" "IPv6 RA disabled" "Annonces routeur IPv6 désactivées" "accept_ra=0" ""
 else
   add_result "Network" "WARN" "NET-10" "IPv6 RA accepted" "Annonces routeur IPv6 acceptées" "accept_ra=$IPV6_RA" \
-    "Si IPv6 non requis: 'net.ipv6.conf.all.accept_ra=0' dans /etc/sysctl.d/"
+    "If IPv6 is not required: 'net.ipv6.conf.all.accept_ra=0' in /etc/sysctl.d/"
 fi
 
 # NET-11 ICMP broadcast ignored
@@ -2201,7 +2201,7 @@ if $TMP_DEDICATED; then
   add_result "Compliance" "PASS" "COMP-02" "/tmp on dedicated partition/tmpfs" "/tmp partition dédiée" "Separate /tmp mount found" ""
 else
   add_result "Compliance" "WARN" "COMP-02" "/tmp not on dedicated partition" "/tmp non isolé" "/tmp not separately mounted" \
-    "Isolez /tmp: ajoutez 'tmpfs /tmp tmpfs defaults,noexec,nosuid,nodev 0 0' dans /etc/fstab"
+    "Isolate /tmp: add 'tmpfs /tmp tmpfs defaults,noexec,nosuid,nodev 0 0' to /etc/fstab"
 fi
 
 # COMP-03 /home on separate partition (informational, cannot change post-install)
@@ -3284,7 +3284,7 @@ footer {
 <thead>
   <tr>
     <th class="col-id">ID</th>
-    <th class="col-status">Statut</th>
+    <th class="col-status">Status</th>
     <th class="col-check">Check</th>
     <th class="col-detail">Detail &amp; Remediation</th>
   </tr>

--- a/scripts/src/checks/compliance.sh
+++ b/scripts/src/checks/compliance.sh
@@ -26,7 +26,7 @@ if $TMP_DEDICATED; then
   add_result "Compliance" "PASS" "COMP-02" "/tmp on dedicated partition/tmpfs" "/tmp partition dédiée" "Separate /tmp mount found" ""
 else
   add_result "Compliance" "WARN" "COMP-02" "/tmp not on dedicated partition" "/tmp non isolé" "/tmp not separately mounted" \
-    "Isolez /tmp: ajoutez 'tmpfs /tmp tmpfs defaults,noexec,nosuid,nodev 0 0' dans /etc/fstab"
+    "Isolate /tmp: add 'tmpfs /tmp tmpfs defaults,noexec,nosuid,nodev 0 0' to /etc/fstab"
 fi
 
 # COMP-03 /home on separate partition (informational, cannot change post-install)

--- a/scripts/src/checks/net.sh
+++ b/scripts/src/checks/net.sh
@@ -99,7 +99,7 @@ if [[ "$IPV6_RA" == "0" ]]; then
   add_result "Network" "PASS" "NET-10" "IPv6 RA disabled" "Annonces routeur IPv6 désactivées" "accept_ra=0" ""
 else
   add_result "Network" "WARN" "NET-10" "IPv6 RA accepted" "Annonces routeur IPv6 acceptées" "accept_ra=$IPV6_RA" \
-    "Si IPv6 non requis: 'net.ipv6.conf.all.accept_ra=0' dans /etc/sysctl.d/"
+    "If IPv6 is not required: 'net.ipv6.conf.all.accept_ra=0' in /etc/sysctl.d/"
 fi
 
 # NET-11 ICMP broadcast ignored

--- a/scripts/src/checks/sys.sh
+++ b/scripts/src/checks/sys.sh
@@ -44,7 +44,7 @@ case "$_SYS_PKG" in
       add_result "System" "PASS" "SYS-03" "No pending security updates" "Système à jour" "0 packages" ""
     else
       add_result "System" "FAIL" "SYS-03" "Pending security updates" "Mises à jour en attente" "$PENDING package(s)" \
-        "Appliquez: '$_SYS_PKG update --security -y'"
+        "Apply: '$_SYS_PKG update --security -y'"
     fi ;;
   apt-get)
     # Scoped to SECURITY updates, like the dnf and zypper branches above it.
@@ -68,7 +68,7 @@ case "$_SYS_PKG" in
     else
       add_result "System" "FAIL" "SYS-03" "Pending security updates" "Mises à jour de sécurité en attente" \
         "${PENDING} security (${_SYS_APT_TOTAL} total pending)" \
-        "Appliquez: 'apt-get upgrade -y' (ou laissez unattended-upgrades le faire)"
+        "Apply: 'apt-get upgrade -y', or let unattended-upgrades do it"
     fi ;;
   zypper)
     # list-patches --category security is the SUSE equivalent of --security.
@@ -78,7 +78,7 @@ case "$_SYS_PKG" in
       add_result "System" "PASS" "SYS-03" "No pending security patches" "Système à jour" "0 patches" ""
     else
       add_result "System" "FAIL" "SYS-03" "Pending security patches" "Correctifs en attente" "$PENDING patch(es)" \
-        "Appliquez: 'zypper patch --category security'"
+        "Apply: 'zypper patch --category security'"
     fi ;;
   pacman)
     # Rolling release: there is no security-only channel, so this is all updates.
@@ -96,7 +96,7 @@ case "$_SYS_PKG" in
       add_result "System" "PASS" "SYS-03" "No pending updates" "Système à jour" "0 packages" ""
     else
       add_result "System" "WARN" "SYS-03" "Pending updates" "Mises à jour en attente" "$PENDING package(s)" \
-        "Appliquez: 'apk upgrade'"
+        "Apply: 'apk upgrade'"
     fi ;;
   none)
     add_result "System" "WARN" "SYS-03" "No package manager found" "Aucun gestionnaire de paquets" \

--- a/scripts/src/renderers/html.sh
+++ b/scripts/src/renderers/html.sh
@@ -781,7 +781,7 @@ footer {
 <thead>
   <tr>
     <th class="col-id">ID</th>
-    <th class="col-status">Statut</th>
+    <th class="col-status">Status</th>
     <th class="col-check">Check</th>
     <th class="col-detail">Detail &amp; Remediation</th>
   </tr>

--- a/scripts/tests/test_french_names.sh
+++ b/scripts/tests/test_french_names.sh
@@ -52,11 +52,61 @@ for f in "${FILES[@]}"; do
   )
 done
 
+# ── The other half: everything that IS rendered must be English ─────────────
+#
+# NAME_FR above is deliberate French that nothing displays. DETAIL and
+# REMEDIATION are the opposite: they are printed in the terminal, written into
+# the JSON and rendered in the HTML report, so French in them is a defect. Six
+# were found by a human opening a report in 2026-08-31: four "Appliquez:" in
+# sys.sh, an "Isolez /tmp: ajoutez ... dans /etc/fstab" and a "Si IPv6 non
+# requis: ... dans /etc/sysctl.d/".
+#
+# The existing prose guard in test_dashboard.sh could not have caught them: it
+# reads the RENDERER, and these strings live in the checks. Guard the fields
+# themselves, extracted the same way the function reads them, so the check is
+# about the category rather than about the six strings that were found.
+#
+# The word list is restricted to French words that are not also English. "plus"
+# is the trap: "plus blacklist iwlwifi" is a correct English remediation and the
+# broader list in test_dashboard.sh flags it.
+fr_rendered='appliquez|ajoutez|isolez|activez|desactivez|d\xc3\xa9sactivez|verifiez|v\xc3\xa9rifiez|installez|configurez|laissez|dans|pour|une|avec|cette|aux|les|des|sont|selon|chaque|leur|entre|sans|requis'
+fr_rendered=$(printf '%b' "$fr_rendered")
+
+rendered=0
+for f in "${FILES[@]}"; do
+  # Args 6 and 7 (DETAIL, REMEDIATION) are optional and usually sit on a
+  # backslash continuation, so the separator class has to allow the backslash
+  # itself. \s alone stops at it and silently matches nothing.
+  while IFS=$'\t' read -r id field text; do
+    [[ -z "${text// }" ]] && continue
+    rendered=$((rendered+1))
+    hit=$(printf '%s' "$text" | grep -oiP "\\b($fr_rendered)\\b" | sort -u | paste -sd, - || true)
+    if [[ -n "$hit" ]]; then
+      bad "$(basename "$f"): $id $field is French ($hit): \"$text\""
+    else
+      ok
+    fi
+  done < <(
+    perl -0777 -ne '
+      while (/add_result[\s\\]+"[^"]*"[\s\\]+"[^"]*"[\s\\]+"([^"]*)"[\s\\]+"[^"]*"[\s\\]+"[^"]*"(?:[\s\\]+"([^"]*)")?(?:[\s\\]+"([^"]*)")?/gs) {
+        my ($id, $detail, $rem) = ($1, $2, $3);
+        print "$id\tDETAIL\t$detail\n"      if defined $detail && $detail ne "";
+        print "$id\tREMEDIATION\t$rem\n"    if defined $rem    && $rem    ne "";
+      }' "$f"
+  )
+done
+
+# Same reasoning as the count assertion below: a guard that reads nothing passes
+# forever. These fields are optional, so the floor is lower than for the names.
+if (( rendered >= 150 )); then ok; else
+  bad "only $rendered detail/remediation strings parsed; expected 150+, so the extraction is broken"
+fi
+
 # The extraction itself has to be believable: if the regex stops matching, every
 # assertion above silently passes on an empty set.
 if (( total >= 200 )); then ok; else
   bad "only $total add_result calls parsed; expected 200+, so the extraction is broken"
 fi
 
-printf '\n%d passed, %d failed  (%d calls checked)\n' "$PASS" "$FAIL" "$total"
+printf '\n%d passed, %d failed  (%d calls checked, %d rendered strings)\n' "$PASS" "$FAIL" "$total" "$rendered"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

Six French strings were reaching rendered output, found while building a demo from a real 15-host audit and reading the report it produced.

| File | String |
|---|---|
| `src/checks/sys.sh` | four `"Appliquez: ..."` remediations (dnf, apt, zypper, apk) |
| `src/checks/compliance.sh` | `"Isolez /tmp: ajoutez ... dans /etc/fstab"` |
| `src/checks/net.sh` | `"Si IPv6 non requis: ... dans /etc/sysctl.d/"` |
| `src/renderers/html.sh` | the results table header read `Statut` |

`DETAIL` and `REMEDIATION` are printed in the terminal, carried in the JSON and rendered in the HTML report, so French in them is a defect. This is not `NAME_FR`, which is untouched and stays complete and unrendered for the reasons `test_french_names.sh` already gives.

## Why the existing guard missed all six

`test_dashboard.sh` reads the **renderer**. Five of the six live in the **checks**, which it never opens. Its word list would also not have matched `Appliquez` or `Statut`.

That is the same shape as the previous miss recorded in that file's own comments: a denylist of the instances already known, rather than a check of the category.

## The guard

`test_french_names.sh` already reads `add_result` positionally for the names. It now also extracts `DETAIL` and `REMEDIATION` and flags French words in them. 384 rendered strings are checked.

Two things that decide whether it works at all:

- **The separator class is `[\s\\]`, not `\s`.** Arguments 6 and 7 usually sit on a backslash continuation, and `\s` stops at the backslash, so the pattern matches nothing and the guard passes on an empty set. There is a floor assertion (150+ strings) for exactly that reason.
- **The word list excludes English-colliding words.** `plus` is the trap: `"plus blacklist iwlwifi"` is a correct English remediation, and the broader list in `test_dashboard.sh` flags it.

## Proven, not assumed

Re-injecting the `net.sh` string, **confirmed present with grep first**, makes the guard fail and name the finding, the field and the matched words:

```
FAIL  net.sh: NET-10 REMEDIATION is French (dans,requis): "Si IPv6 non requis: ..."
616 passed, 1 failed  (231 calls checked, 384 rendered strings)
```

## Verification

- `test_french_names.sh` 617 passed, 0 failed
- Full suite green: aartool 128, check_commands 15, dashboard 41, distro 26, docs 195, escaping 14, remediation_map 441, service_guards 49, versions 19, waves 218
- `shellcheck -S warning` clean on both CI command lines
- Both bundles rebuilt; `scripts/aartool` is unchanged (the checks live in the baseline), so `git diff --exit-code` in CI stays clean

## Not in this PR

The report's status badges are emoji (`✅` U+2705, `⚠️`, `❌`). On a host with no emoji font installed, `✅` renders as a tofu box while the other two survive in DejaVu. Worth a follow-up decision on whether the report should carry glyphs that depend on a font the reader may not have, but it is a separate question from the language and I have not touched it.
