### PR TITLE
docs: the apt install is two commands now, and say why it is not one

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,8 @@ From the package repository, which is what most people want:
 
 ```bash
 # Debian, Ubuntu
-sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://pkgs.cyberaar.io/gpg | sudo tee /etc/apt/keyrings/aartool.asc >/dev/null
-sudo chmod a+r /etc/apt/keyrings/aartool.asc
-echo "deb [signed-by=/etc/apt/keyrings/aartool.asc] https://pkgs.cyberaar.io/deb stable main" \
-  | sudo tee /etc/apt/sources.list.d/aartool.list
+sudo curl -fsSL https://pkgs.cyberaar.io/aartool.sources \
+  -o /etc/apt/sources.list.d/aartool.sources
 sudo apt update && sudo apt install aartool
 
 # RHEL, Rocky, AlmaLinux, Fedora
@@ -86,10 +83,19 @@ sudo curl -fsSL https://pkgs.cyberaar.io/aartool.repo -o /etc/yum.repos.d/aartoo
 sudo dnf install aartool
 ```
 
-The `chmod a+r` is not decoration. apt verifies signatures as the unprivileged
-`_apt` user, and `sudo tee` creates the file with your umask: on a machine set
-to `umask 027` that is mode 0640, `_apt` cannot read it, and apt fails with
-`Unknown error executing apt-key`, which names neither permissions nor the file.
+Two commands, not one. `apt install aartool` on its own reports `E: Unable to
+locate package aartool`, because apt will not install from a repository it has
+not been told to trust, and it cannot be told from inside the install command.
+That is apt's trust model, not something this packaging can shorten.
+
+The apt file is [deb822](https://manpages.debian.org/apt/sources.list.5.en.html)
+with the signing key **inline**, which is what makes it one file instead of
+three. The older form needs the key in `/etc/apt/keyrings` and then needs it
+made world readable, because apt verifies signatures as the unprivileged `_apt`
+user and `curl | sudo tee` writes the file with your umask: on a machine set to
+`umask 027` that is mode 0640, and apt fails with `Unknown error executing
+apt-key`, naming neither the permission nor the file. Inline, there is no
+second file to get wrong.
 
 Both packages are signed, and so is the repository metadata. `apt upgrade` and
 `dnf upgrade` pick up new releases from then on.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -70,10 +70,15 @@ mistake with `apply` has always been the wrong target rather than the wrong
 intent. Absent, aartool prints the same copy-the-example message it prints for a
 fresh clone.
 
-## The keyring has to be world readable
+## The keyring had to be world readable, and now there is no keyring
+
+**Superseded.** The documented apt install is now a single deb822 `.sources`
+file with the signing key inline, served from `https://pkgs.cyberaar.io/aartool.sources`,
+so there is no separate keyring file and nothing to chmod. The rest of this
+section is why that file exists; it is not a step anyone still runs.
 
 apt verifies signatures as the unprivileged `_apt` user, not as root. The
-documented install therefore ends with:
+install used to end with:
 
 ```bash
 sudo chmod a+r /etc/apt/keyrings/aartool.asc
@@ -98,6 +103,17 @@ and the missing `chmod` never mattered. The install test now runs under
 `umask 027` for exactly this reason. It is the second time this machine's umask
 has produced a defect: the first packages built were 0640 throughout, readable
 only by root.
+
+The deb822 file removes the class rather than the instance: with the key inline
+there is no second file whose permissions can be wrong. Verified under
+`umask 027` on `ubuntu:24.04` against the live URL, where the `.sources` file
+itself lands 0640 and apt reads it without complaint, because the file `_apt`
+needed to read no longer exists.
+
+`apt install aartool` on its own is still not possible and never will be. With
+no repository configured apt reports `E: Unable to locate package aartool`;
+it will not install from a repository it has not been told to trust, and it
+cannot be told from inside the install command. Two commands is the floor.
 
 ## Symlinks inside a packaged directory are dropped
 


### PR DESCRIPTION
## Why

Someone read the install section and asked whether it could be reduced to just `apt install aartool`.

It cannot, and the previous wording invited the question by presenting six lines without saying which of them were unavoidable.

## The answer, now in the README

```
$ apt-get install -y aartool
E: Unable to locate package aartool
```

apt will not install from a repository it has not been told to trust, and it cannot be told from inside the install command. **Two commands is the floor.**

## But four was not the floor

`pkgs.cyberaar.io` now serves a deb822 `.sources` file with the signing key inline (aarsoc-infra **#431**, already deployed), so Debian and Ubuntu drop one file and install, the same shape RHEL has always had:

```bash
sudo curl -fsSL https://pkgs.cyberaar.io/aartool.sources \
  -o /etc/apt/sources.list.d/aartool.sources
sudo apt update && sudo apt install aartool
```

That also retires the `chmod a+r` line, which `docs/PACKAGING.md` records as having shipped and hit a real user.

## PACKAGING.md

The "keyring has to be world readable" section is marked **superseded**, not deleted. The chmod it documents is no longer a step anyone runs, but it is precisely why the `.sources` file exists, and that section is also where the umask lesson lives — the one that says the install test now runs under `umask 027` because a root container with `umask 022` hid the bug.

Added there: the deb822 file removes the class rather than the instance. With the key inline there is no second file whose permissions can be wrong.

## Verification

Clean `ubuntu:24.04`, `umask 027`, against the live URL rather than a built tree:

```
installed: aartool 3.5.3
explain works:
SSH-01  PermitRootLogin disabled
Category: SSH
advise reachable:
aartool advise: turn an audit into an ordered plan
```

`test_docs.sh`: 195 passed, 0 failed. That guard checks every fenced aartool invocation in README and AARTOOL.md against the CLI's own `--help`, so the new block is checked rather than trusted.
